### PR TITLE
Bugfix: forced_return<T>() did lead to compile-time errors for move-only...

### DIFF
--- a/include/boost/variant/detail/forced_return.hpp
+++ b/include/boost/variant/detail/forced_return.hpp
@@ -41,10 +41,7 @@ inline T forced_return()
 {
     // logical error: should never be here! (see above)
     BOOST_ASSERT(false);
-
-    typedef typename boost::remove_reference<T>::type basic_type;
-    basic_type* dummy = 0;
-    return *static_cast< basic_type* >(dummy);
+    throw;
 }
 
 template <>


### PR DESCRIPTION
... types.

When implementing a visitor that returns an std::unique_ptr<T> the code compiled in Visual Studio 2010 and 2012, but not with GCC 4.8.2 since the copy constructor is required in the line 

```
return *static_cast< basic_type* >(dummy);
```

This line is not compiled under Visual Studio since it is checked whether the macro BOOST_MSVC is defined. It should be ok to throw here, since the code is not called at run-time anyways. 

Throwing should work in most circumstances, but I'm not sure what to do in the case where RTTI is disabled and hence exceptions are not allowed. Possibly a recursive call to forced_return<T>() is an alternative here. I don't fully comprehend what forced_return is needed for. If someone's reading this, please check if 

```
return forced_return<T>();
```

would not be a better line to put here.
