### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -7,7 +7,7 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 
-project boost/doc ;
+project variant/doc ;
 import boostbook : boostbook ;
 
 boostbook variant-doc 


### PR DESCRIPTION
There can only be one Jamfile named "boost/doc" and we have than already under /doc/
Change to a unique name,
Fixes PDF doc build.
