### PR TITLE
Add missing headers in get.hpp and element_index.hpp

### DIFF
--- a/include/boost/variant/detail/element_index.hpp
+++ b/include/boost/variant/detail/element_index.hpp
@@ -13,6 +13,7 @@
 #define BOOST_VARIANT_DETAIL_ELEMENT_INDEX_HPP
 
 #include "boost/config.hpp"
+#include "boost/variant/recursive_wrapper_fwd.hpp"
 #include "boost/variant/variant_fwd.hpp"
 #include "boost/detail/reference_content.hpp"
 

--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -17,6 +17,7 @@
 
 #include "boost/config.hpp"
 #include "boost/detail/workaround.hpp"
+#include "boost/static_assert.hpp"
 #include "boost/throw_exception.hpp"
 #include "boost/utility/addressof.hpp"
 #include "boost/variant/variant_fwd.hpp"


### PR DESCRIPTION
If `boost/variant/get.hpp` is included before other Variant headers the compiler can't find `boost::recursive_wrapper<>`.