### PR TITLE
Add missing header in variant.hpp

### DIFF
--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -48,6 +48,7 @@
 #include "boost/type_traits/add_const.hpp"
 #include "boost/type_traits/has_nothrow_constructor.hpp"
 #include "boost/type_traits/has_nothrow_copy.hpp"
+#include "boost/type_traits/is_nothrow_move_assignable.hpp"
 #include "boost/type_traits/is_nothrow_move_constructible.hpp"
 #include "boost/type_traits/is_const.hpp"
 #include "boost/type_traits/is_same.hpp"


### PR DESCRIPTION
because of the recent TypeTraits dependency drop in Move.

see https://github.com/boostorg/move/commit/8503b508e8028e5d433379c2963cc8d774214a5e