### PR TITLE
Lambda Visitor

### DIFF
--- a/include/boost/variant/detail/lambda_visitor_deduction.hpp
+++ b/include/boost/variant/detail/lambda_visitor_deduction.hpp
@@ -1,0 +1,165 @@
+//  Boost.Varaint
+//  Lambda Visitor utilities defined here
+//
+//  See http://www.boost.org for most recent version, including documentation.
+//
+//  Copyright Klemens Morgenstern, 2015.
+//
+//  Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt).
+
+#ifndef BOOST_VARIANT_DETAIL_LAMBDA_VISITOR_DEDUCTION_HPP
+#define BOOST_VARIANT_DETAIL_LAMBDA_VISITOR_DEDUCTION_HPP
+
+#include <boost/type_traits/is_same.hpp>
+#include <boost/core/enable_if.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/type_traits/remove_cv.hpp>
+
+namespace boost {
+namespace detail { namespace variant {
+
+//cause i don't wanna include utility; doesn't really make sense, since i already use c++11
+template< class T >
+constexpr T&& forward( typename remove_reference<T>::type& t )
+{
+	return t;
+}
+template< class T >
+constexpr T&& forward( typename remove_reference<T>::type&& t )
+{
+	return static_cast<T&&>(t);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+// lambda_types, just a simple holder for the argument types of the tuple. I think that has less compiling
+// overhead than using boost.tuple or std.tuple
+//
+template<typename ...Args> struct lambda_types{};
+
+template<typename type_list, typename ...Args>
+using lambda_fit_types = is_same<type_list, lambda_types<
+				typename remove_reference<
+					typename remove_cv<Args>::type
+						>::type...>>;
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+// lambda_parameter_deduction deduct the return type and the parameters of the input.
+//
+template<typename lambda>
+struct lambda_parameter_deduction
+{
+};
+//the ... comes from possible mutli visitors.
+template<typename lambda, typename Ret, typename ... Arg>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg...) const>
+{
+	typedef lambda_types<remove_reference<remove_cv<Arg>>...> types;
+	typedef Ret return_type;
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+// used for the actual deduction
+//
+template<typename Lambda>
+struct lambda_deduct_parameter
+{
+	using types		  = typename lambda_parameter_deduction<decltype(&Lambda::operator())>::types;
+	using return_type = typename lambda_parameter_deduction<decltype(&Lambda::operator())>::return_type;
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+// the void helper is used to allow a possible handling of a void lambda, by using a specialization
+//
+template<typename Return_Type, typename Lambda>
+class lambda_void_helper
+{
+	Lambda _lambda;
+public:
+	template<typename L>
+	lambda_void_helper(L &&lambda) : _lambda(forward<L>(lambda)) {};
+	using types			= typename lambda_deduct_parameter<Lambda>::types;
+	using return_type	= typename lambda_deduct_parameter<Lambda>::return_type;
+
+	template<typename ... Args>
+	typename enable_if<lambda_fit_types<types, Args...>, return_type>::type operator()(Args && ... args) const
+	{
+		return _lambda(forward<Args>(args)...);
+	}
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  used if the lambda returns void.
+//
+template<typename Lambda>
+class lambda_void_helper<void, Lambda>
+{
+	Lambda _lambda;
+public:
+	template<typename L>
+	lambda_void_helper(L &&lambda) : _lambda(forward<L>(lambda)) {};
+	using types 		= typename lambda_deduct_parameter<Lambda>::types;
+	using return_type	= typename lambda_deduct_parameter<Lambda>::return_type;
+
+
+	template<typename ... Args>
+	typename enable_if<lambda_fit_types<types, Args...>> operator()(Args&&... args) const
+	{
+		_lambda(forward<Args>(args)...);
+	}
+};
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  declaration of the actual visitor, i.e. this one is partial and gets inherited
+//
+template<typename ... Args>
+class lambda_visitor_helper
+{
+	void operator()();
+};
+
+template<typename Lambda>
+class lambda_visitor_helper<Lambda> : public lambda_void_helper<typename lambda_deduct_parameter<Lambda>::return_type, Lambda>
+{
+	using father = lambda_void_helper<typename lambda_deduct_parameter<Lambda>::return_type, Lambda>;
+public:
+	using return_type = typename father::return_type;
+	using father::operator();
+
+	template<typename L>
+	lambda_visitor_helper(L &&lambda) : father(forward<L>(lambda)) {};
+};
+
+template<typename Lambda, typename ... Args>
+class lambda_visitor_helper<Lambda, Args...> : public lambda_visitor_helper<Args...>, public lambda_void_helper<typename lambda_deduct_parameter<Lambda>::return_type, Lambda>
+{
+	using father = lambda_void_helper<typename lambda_deduct_parameter<Lambda>::return_type, Lambda>;
+	static_assert(boost::is_same<typename father::return_type, typename lambda_visitor_helper<Args...>::return_type>::value, "return types must have the same type");
+public:
+	using lambda_visitor_helper<Args...>::operator();
+	using return_type = typename father::return_type;
+	using father::operator();
+
+	template<typename L, typename ... l_Args>
+	lambda_visitor_helper(L && lambda, l_Args && ...ls) :
+			lambda_visitor_helper<Args...>(forward<l_Args>(ls)...), father(forward<Lambda>(lambda)) {};
+};
+
+template<typename ...Args>
+struct lambda_visitor : public lambda_visitor_helper<Args...>, public boost::static_visitor<typename lambda_visitor_helper<Args...>::return_type>
+{
+	using return_type = typename lambda_visitor_helper<Args...>::return_type;
+	using lambda_visitor_helper<Args...>::operator();
+	lambda_visitor(Args&&...args) : lambda_visitor_helper<Args...>(forward<Args>(args)...) {};
+};
+
+
+}}}
+
+
+
+
+#endif /* BOOST_VARIANT_DETAIL_LAMBDA_VISITOR_DEDUCTION_HPP_ */

--- a/include/boost/variant/detail/lambda_visitor_deduction.hpp
+++ b/include/boost/variant/detail/lambda_visitor_deduction.hpp
@@ -16,13 +16,14 @@
 #include <boost/core/enable_if.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_cv.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 namespace boost {
 namespace detail { namespace variant {
 
-//cause i don't wanna include utility; doesn't really make sense, since i already use c++11
+//cause i don't wanna include utility; doesn't really make sense, since i already use c++14
 template< class T >
-constexpr T&& forward( typename remove_reference<T>::type& t )
+constexpr T& forward( typename remove_reference<T>::type& t )
 {
 	return t;
 }
@@ -33,32 +34,108 @@ constexpr T&& forward( typename remove_reference<T>::type&& t )
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
-// lambda_types, just a simple holder for the argument types of the tuple. I think that has less compiling
-// overhead than using boost.tuple or std.tuple
+// I did not find a SFINAE solution for multi-visitors, so I will do that by hand. up to 10 we go.
 //
-template<typename ...Args> struct lambda_types{};
-
-template<typename type_list, typename ...Args>
-using lambda_fit_types = is_same<type_list, lambda_types<
-				typename remove_reference<
-					typename remove_cv<Args>::type
-						>::type...>>;
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 // lambda_parameter_deduction deduct the return type and the parameters of the input.
+//
 //
 template<typename lambda>
 struct lambda_parameter_deduction
 {
 };
 //the ... comes from possible mutli visitors.
-template<typename lambda, typename Ret, typename ... Arg>
-struct lambda_parameter_deduction<Ret(lambda::*)(Arg...) const>
+template<typename lambda, typename Ret, typename Arg0>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0) const>
 {
-	typedef lambda_types<remove_reference<remove_cv<Arg>>...> types;
+	typedef Arg0 type0;
+	static constexpr size_t arg_cout = 1;
 	typedef Ret return_type;
 };
+
+template<typename lambda, typename Ret, typename Arg0, typename Arg1>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0, Arg1) const>
+{
+	typedef Arg0 type0;
+	typedef Arg1 type1;
+
+	static constexpr size_t arg_cout = 2;
+	typedef Ret return_type;
+};
+
+template<typename lambda, typename Ret, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4,
+										typename Arg5, typename Arg6>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) const>
+{
+	typedef Arg0 type0;
+	typedef Arg1 type1;
+	typedef Arg2 type2;
+	typedef Arg3 type3;
+	typedef Arg4 type4;
+	typedef Arg5 type5;
+	typedef Arg6 type6;
+	static constexpr size_t arg_cout = 7;
+	typedef Ret return_type;
+};
+
+template<typename lambda, typename Ret, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4,
+										typename Arg5, typename Arg6, typename Arg7>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) const>
+{
+	typedef Arg0 type0;
+	typedef Arg1 type1;
+	typedef Arg2 type2;
+	typedef Arg3 type3;
+	typedef Arg4 type4;
+	typedef Arg5 type5;
+	typedef Arg6 type6;
+	typedef Arg7 type7;
+
+	static constexpr size_t arg_cout = 8;
+	typedef Ret return_type;
+};
+
+template<typename lambda, typename Ret, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4,
+										typename Arg5, typename Arg6, typename Arg7, typename Arg8>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) const>
+{
+	typedef Arg0 type0;
+	typedef Arg1 type1;
+	typedef Arg2 type2;
+	typedef Arg3 type3;
+	typedef Arg4 type4;
+	typedef Arg5 type5;
+	typedef Arg6 type6;
+	typedef Arg7 type7;
+	typedef Arg8 type8;
+
+	static constexpr size_t arg_cout = 9;
+	typedef Ret return_type;
+};
+
+template<typename lambda, typename Ret, typename Arg0, typename Arg1, typename Arg2, typename Arg3, typename Arg4,
+										typename Arg5, typename Arg6, typename Arg7, typename Arg8, typename Arg9>
+struct lambda_parameter_deduction<Ret(lambda::*)(Arg0, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) const>
+{
+	typedef Arg0 type0;
+	typedef Arg1 type1;
+	typedef Arg2 type2;
+	typedef Arg3 type3;
+	typedef Arg4 type4;
+	typedef Arg5 type5;
+	typedef Arg6 type6;
+	typedef Arg7 type7;
+	typedef Arg8 type8;
+	typedef Arg9 type9;
+
+	static constexpr size_t arg_cout = 10;
+	typedef Ret return_type;
+};
+
+
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 // used for the actual deduction
@@ -78,13 +155,15 @@ class lambda_void_helper
 {
 	Lambda _lambda;
 public:
+	template<size_t Index, typename ...Args>
+	using arg = lambda_arg_type<Index, Args>;
+
 	template<typename L>
 	lambda_void_helper(L &&lambda) : _lambda(forward<L>(lambda)) {};
 	using types			= typename lambda_deduct_parameter<Lambda>::types;
 	using return_type	= typename lambda_deduct_parameter<Lambda>::return_type;
 
-	template<typename ... Args>
-	typename enable_if<lambda_fit_types<types, Args...>, return_type>::type operator()(Args && ... args) const
+	return_type operator()(arg<0, types>) const
 	{
 		return _lambda(forward<Args>(args)...);
 	}
@@ -105,7 +184,7 @@ public:
 
 
 	template<typename ... Args>
-	typename enable_if<lambda_fit_types<types, Args...>> operator()(Args&&... args) const
+	typename enable_if<lambda_fit_types<types, Args...>::value>::type operator()(Args&&... args) const
 	{
 		_lambda(forward<Args>(args)...);
 	}

--- a/include/boost/variant/detail/lambda_visitor_deduction.hpp
+++ b/include/boost/variant/detail/lambda_visitor_deduction.hpp
@@ -102,7 +102,7 @@ public:
 
 	template<typename L, typename ... l_Args>
 	lambda_visitor_helper(L && lambda, l_Args && ...ls) :
-			lambda_visitor_helper<Args...>(forward<l_Args>(ls)...), father(forward<Lambda>(lambda)) {};
+			lambda_visitor_helper<Args...>(forward<l_Args>(ls)...), father(forward<L>(lambda)) {};
 };
 
 template<typename ...Args>
@@ -113,6 +113,49 @@ struct lambda_visitor : public lambda_visitor_helper<Args...>, public boost::sta
 	lambda_visitor(Args&&...args) : lambda_visitor_helper<Args...>(forward<Args>(args)...) {};
 };
 
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////
+//  explicit lambda visitor
+//
+template<typename ... Args>
+class lambda_visitor_helper_exp
+{
+	void operator()();
+};
+
+
+
+template<typename Lambda>
+class lambda_visitor_helper_exp<Lambda> : public Lambda
+{
+	using father = Lambda;
+public:
+	using father::operator();
+	template<typename L>
+	lambda_visitor_helper_exp(L &&lambda) : father(forward<L>(lambda)) {};
+};
+
+template<typename Lambda, typename ... Args>
+class lambda_visitor_helper_exp<Lambda, Args...> : public lambda_visitor_helper_exp<Args...>, public Lambda
+{
+	using father = Lambda;
+public:
+	using lambda_visitor_helper_exp<Args...>::operator();
+	using father::operator();
+
+	template<typename L, typename ... l_Args>
+	lambda_visitor_helper_exp(L && lambda, l_Args && ...ls) :
+		lambda_visitor_helper_exp<l_Args...>(forward<l_Args>(ls)...), father(forward<L>(lambda)) {};
+};
+
+template<typename ReturnType, typename ...Args>
+struct lambda_visitor_exp : public lambda_visitor_helper_exp<Args...>, public boost::static_visitor<ReturnType>
+{
+	using return_type = ReturnType;
+	using lambda_visitor_helper_exp<Args...>::operator();
+	lambda_visitor_exp(Args&&...args) : lambda_visitor_helper_exp<Args...>(forward<Args>(args)...) {};
+};
 
 }}}
 

--- a/include/boost/variant/detail/move.hpp
+++ b/include/boost/variant/detail/move.hpp
@@ -26,7 +26,7 @@
 #include "boost/config.hpp"
 #include "boost/detail/workaround.hpp"
 #include "boost/move/move.hpp"
-//#include "boost/move/adl_move_swap.hpp"
+#include "boost/move/adl_move_swap.hpp"
 
 namespace boost { namespace detail { namespace variant {
 
@@ -42,7 +42,7 @@ using boost::move;
 template <typename T>
 inline void move_swap(T& lhs, T& rhs)
 {
-   // ::boost::adl_move_swap(lhs, rhs);
+    ::boost::adl_move_swap(lhs, rhs);
 }
 
 }}} // namespace boost::detail::variant

--- a/include/boost/variant/detail/move.hpp
+++ b/include/boost/variant/detail/move.hpp
@@ -26,7 +26,7 @@
 #include "boost/config.hpp"
 #include "boost/detail/workaround.hpp"
 #include "boost/move/move.hpp"
-#include "boost/move/adl_move_swap.hpp"
+//#include "boost/move/adl_move_swap.hpp"
 
 namespace boost { namespace detail { namespace variant {
 
@@ -42,7 +42,7 @@ using boost::move;
 template <typename T>
 inline void move_swap(T& lhs, T& rhs)
 {
-    ::boost::adl_move_swap(lhs, rhs);
+   // ::boost::adl_move_swap(lhs, rhs);
 }
 
 }}} // namespace boost::detail::variant

--- a/include/boost/variant/lambda_visitor.hpp
+++ b/include/boost/variant/lambda_visitor.hpp
@@ -1,0 +1,39 @@
+//  Boost.Varaint
+//  Multivisitors defined here
+//
+//  See http://www.boost.org for most recent version, including documentation.
+//
+//  Copyright Klemens Morgenstern, 2015.
+//
+//  Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt).
+
+#ifndef BOOST_VARIANT_LAMBDA_VISITOR_HPP
+#define BOOST_VARIANT_LAMBDA_VISITOR_HPP
+
+#include "boost/variant/static_visitor.hpp"
+#include "boost/variant/detail/lambda_visitor_deduction.hpp"
+
+#include <type_traits>
+
+namespace boost { //namespace variant {
+
+
+
+template<typename ...Lambdas>
+detail::variant::lambda_visitor<Lambdas...> make_lambda_visitor(Lambdas && ...args) {return lambda_visitor<Lambdas...>(detail::variant::forward<Lambdas>(args)...);}
+
+
+template<typename Variant, typename ...Lambdas>
+auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> detail::variant::lambda_visitor<Lambdas>::return_type
+{
+	auto vis = make_lambda_visitor(lambdas...);
+	var.apply_visitor(vis);
+}
+
+}//}
+
+
+
+#endif /* LAMBDA_VISITOR_H_ */

--- a/include/boost/variant/lambda_visitor.hpp
+++ b/include/boost/variant/lambda_visitor.hpp
@@ -17,7 +17,7 @@
 
 #include <type_traits>
 
-namespace boost { //namespace variant {
+namespace boost {
 
 
 
@@ -26,13 +26,14 @@ detail::variant::lambda_visitor<Lambdas...> make_lambda_visitor(Lambdas && ...ar
 
 
 template<typename Variant, typename ...Lambdas>
-auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> typename detail::variant::lambda_visitor<Lambdas>::return_type
+auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> typename detail::variant::lambda_visitor<Lambdas...>::return_type
 {
-	auto vis = make_lambda_visitor(lambdas...);
-	var.apply_visitor(vis);
-}
+	using Ret = typename detail::variant::lambda_visitor<Lambdas...>::return_type;
+	auto vis = make_lambda_visitor(detail::variant::forward<Lambdas>(lambdas)...);
+	return Ret(var.apply_visitor(vis));//type
+};
 
-}//}
+}
 
 
 

--- a/include/boost/variant/lambda_visitor.hpp
+++ b/include/boost/variant/lambda_visitor.hpp
@@ -22,11 +22,11 @@ namespace boost { //namespace variant {
 
 
 template<typename ...Lambdas>
-detail::variant::lambda_visitor<Lambdas...> make_lambda_visitor(Lambdas && ...args) {return lambda_visitor<Lambdas...>(detail::variant::forward<Lambdas>(args)...);}
+detail::variant::lambda_visitor<Lambdas...> make_lambda_visitor(Lambdas && ...args) {return detail::variant::lambda_visitor<Lambdas...>(detail::variant::forward<Lambdas>(args)...);}
 
 
 template<typename Variant, typename ...Lambdas>
-auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> detail::variant::lambda_visitor<Lambdas>::return_type
+auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> typename detail::variant::lambda_visitor<Lambdas>::return_type
 {
 	auto vis = make_lambda_visitor(lambdas...);
 	var.apply_visitor(vis);

--- a/include/boost/variant/lambda_visitor.hpp
+++ b/include/boost/variant/lambda_visitor.hpp
@@ -15,8 +15,6 @@
 #include "boost/variant/static_visitor.hpp"
 #include "boost/variant/detail/lambda_visitor_deduction.hpp"
 
-#include <type_traits>
-
 namespace boost {
 
 
@@ -32,6 +30,22 @@ auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> typename detail::varia
 	auto vis = make_lambda_visitor(detail::variant::forward<Lambdas>(lambdas)...);
 	return Ret(var.apply_visitor(vis));//type
 };
+
+///explicit version
+
+template<typename ReturnType, typename ...Lambdas>
+detail::variant::lambda_visitor_exp<ReturnType, Lambdas...> make_lambda_visitor(Lambdas && ...args) {return detail::variant::lambda_visitor_exp<ReturnType, Lambdas...>(detail::variant::forward<Lambdas>(args)...);}
+
+
+template<typename ReturnType, typename Variant, typename ...Lambdas>
+auto apply_lambdas(Variant & var, Lambdas ... lambdas) -> ReturnType
+{
+//	using Ret = typename detail::variant::lambda_visitor<Lambdas...>::return_type;
+	auto vis = make_lambda_visitor<ReturnType>(detail::variant::forward<Lambdas>(lambdas)...);
+	return ReturnType(var.apply_visitor(vis));//type
+};
+
+
 
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -47,6 +47,7 @@ test-suite variant
     [ run lambda_test1.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test1 ]
     [ run lambda_test2.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test2 ]
     [ run lambda_test3.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test3 ]
+    [ run lambda_test4.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test3 ]
     [ run recursive_variant_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : variant_no_rtti_test ]
     [ run variant_swap_test.cpp ]
     [ run auto_visitors.cpp ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -44,6 +44,9 @@ test-suite variant
       <toolset>clang:<cxxflags>-fno-exceptions
       : variant_noexcept_test
     ]
+    [ run lambda_test1.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test1 ]
+    [ run lambda_test2.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test2 ]
+    [ run lambda_test3.cpp : : : <toolset>gcc:<cxxflags>-std=c++1y: lambda_visitor_test3 ]
     [ run recursive_variant_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : variant_no_rtti_test ]
     [ run variant_swap_test.cpp ]
     [ run auto_visitors.cpp ]

--- a/test/lambda_test1.cpp
+++ b/test/lambda_test1.cpp
@@ -54,8 +54,8 @@ void run()
 
    auto ts = boost::make_lambda_visitor(
 		   [&](string & st){v1c = st;},
-   	   	   [&](char c)	  {v1b = c;},
-		   [&](const double & db) {v1c = db;}
+   	   	   [&](int c)	  {v1b = c;},
+		   [&](const double & db) {v1a = db;}
    	   	   );
 
    static_assert(boost::is_same<typename decltype(ts)::return_type, void>::value, "Return type is incorrect");
@@ -88,7 +88,7 @@ void run()
    ///ok, now with a return value
    auto ts2 = boost::make_lambda_visitor(
 		   [&](string  st)  -> string {return st;},
-   	   	   [&](char c)	   -> string {return {c};},
+   	   	   [&](int i)	   -> string  {return std::to_string(i);},
 		   [&](double  db)  -> string {return std::to_string(db);}
    	   	   );
 
@@ -99,11 +99,11 @@ void run()
 
 
    v1 = "C3P0";
-   BOOST_CHECK(apply_visitor(ts2, v1) == "C3PO");
+   BOOST_CHECK(apply_visitor(ts2, v1) == "C3P0");
 
 
-   v1 = 'C';
-   BOOST_CHECK(apply_visitor(ts2, v1) != "C");
+   v1 = 42;
+   BOOST_CHECK(apply_visitor(ts2, v1) == std::to_string(42));
 
 
 }

--- a/test/lambda_test1.cpp
+++ b/test/lambda_test1.cpp
@@ -1,0 +1,119 @@
+
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/lambda_test1.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Copyright (c) 2015
+// Klemens Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost/config.hpp"
+
+#ifdef BOOST_MSVC
+#pragma warning(disable:4244) // conversion from const int to const short
+#endif
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant.hpp"
+#include "boost/variant/lambda_visitor.hpp"
+
+#include "class_a.h"
+#include "jobs.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+
+void run()
+{
+
+   using boost::apply_visitor;
+   using boost::variant;
+   using std::string;
+   using std::vector;
+   using std::cout;
+   using std::endl;
+
+   typedef variant< int, string, double > t_var1;
+
+
+   t_var1 v1;
+
+
+
+   //
+   // Check the standard call, returning nothing
+   //
+   double v1a = 0.;
+   char   v1b = '0';
+   string v1c = "";
+
+   auto ts = boost::make_lambda_visitor(
+		   [&](string & st){v1c = st;},
+   	   	   [&](char c)	  {v1b = c;},
+		   [&](const double & db) {v1c = db;}
+   	   	   );
+
+   static_assert(boost::is_same<typename decltype(ts)::return_type, void>::value, "Return type is incorrect");
+
+
+   v1 = 5.9;
+   apply_visitor(ts, v1);
+
+   BOOST_CHECK(v1a == 5.9);
+   BOOST_CHECK(v1b == '0');
+   BOOST_CHECK(v1c == "");
+
+
+   v1 = "Yippie-Ki-Yay";
+   apply_visitor(ts, v1);
+
+   BOOST_CHECK(v1a == 5.9);
+   BOOST_CHECK(v1b == '0');
+   BOOST_CHECK(v1c == "Yippie-Ki-Yay");
+
+
+   v1 = 'C';
+   apply_visitor(ts, v1);
+
+   BOOST_CHECK(v1a == 5.9);
+   BOOST_CHECK(v1b == 'C');
+   BOOST_CHECK(v1c == "Yippie-Ki-Yay");
+
+
+   ///ok, now with a return value
+   auto ts2 = boost::make_lambda_visitor(
+		   [&](string  st)  -> string {return st;},
+   	   	   [&](char c)	   -> string {return {c};},
+		   [&](double  db)  -> string {return std::to_string(db);}
+   	   	   );
+
+   static_assert(boost::is_same<typename decltype(ts2)::return_type, string>::value, "Return type is incorrect");
+
+   v1 = 3.124;
+   BOOST_CHECK(apply_visitor(ts, v1) == std::to_string(3.124));
+
+
+   v1 = "C3P0";
+   BOOST_CHECK(apply_visitor(ts, v1) == "C3PO");
+
+
+   v1 = 'C';
+   BOOST_CHECK(apply_visitor(ts, v1) != "C");
+
+
+}
+
+
+
+int test_main(int , char* [])
+{
+   run();
+   return 0;
+}

--- a/test/lambda_test1.cpp
+++ b/test/lambda_test1.cpp
@@ -21,8 +21,6 @@
 #include "boost/variant.hpp"
 #include "boost/variant/lambda_visitor.hpp"
 
-#include "class_a.h"
-#include "jobs.h"
 
 #include <iostream>
 #include <string>
@@ -97,15 +95,15 @@ void run()
    static_assert(boost::is_same<typename decltype(ts2)::return_type, string>::value, "Return type is incorrect");
 
    v1 = 3.124;
-   BOOST_CHECK(apply_visitor(ts, v1) == std::to_string(3.124));
+   BOOST_CHECK(apply_visitor(ts2, v1) == std::to_string(3.124));
 
 
    v1 = "C3P0";
-   BOOST_CHECK(apply_visitor(ts, v1) == "C3PO");
+   BOOST_CHECK(apply_visitor(ts2, v1) == "C3PO");
 
 
    v1 = 'C';
-   BOOST_CHECK(apply_visitor(ts, v1) != "C");
+   BOOST_CHECK(apply_visitor(ts2, v1) != "C");
 
 
 }

--- a/test/lambda_test2.cpp
+++ b/test/lambda_test2.cpp
@@ -1,0 +1,95 @@
+
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/lambda_test2.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Copyright (c) 2015
+// Klemens Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost/config.hpp"
+
+#ifdef BOOST_MSVC
+#pragma warning(disable:4244) // conversion from const int to const short
+#endif
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant.hpp"
+#include "boost/variant/lambda_visitor.hpp"
+
+#include "class_a.h"
+#include "jobs.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+
+void run()
+{
+
+   using boost::apply_visitor;
+   using boost::variant;
+   using std::string;
+   using std::vector;
+   using std::cout;
+   using std::endl;
+   using std::nullptr_t;
+
+   typedef variant< int, double > t_var1;
+   typedef variant< string, nullptr_t> t_var2;
+
+   t_var1 v1;
+   t_var2 v2;
+
+
+   enum types_t
+   {
+	   int_string,
+	   double_string,
+	   int_nullptr,
+	   double_nullptr,
+   };
+
+   //
+   // The whole test is done by the return value, cause that's simple.
+   //
+
+
+   auto ts = boost::make_lambda_visitor(
+		   [](int, string )			{return int_string;},
+   	   	   [](int, nullptr_t)		{return int_nullptr;},
+		   [](double, string )		{return double_string;},
+   	   	   [](double, nullptr_t)	{return double_nullptr;}
+
+		    	   	   );
+
+   static_assert(boost::is_same<typename decltype(ts)::return_type, types_t>::value, "Return type is incorrect");
+
+
+   v1 = 5.9;
+   v2 = nullptr;
+   BOOST_CHECK(apply_visitor(ts, v1, v2) == double_nullptr);
+
+   v1 = 42;
+   BOOST_CHECK(apply_visitor(ts, v1, v2) == int_nullptr);
+
+   v2 = "R2-D2";
+   BOOST_CHECK(apply_visitor(ts, v1, v2) == int_string);
+
+   v1 = 3.124;
+   BOOST_CHECK(apply_visitor(ts, v1, v2) == double_string);
+}
+
+
+
+int test_main(int , char* [])
+{
+   run();
+   return 0;
+}

--- a/test/lambda_test2.cpp
+++ b/test/lambda_test2.cpp
@@ -21,8 +21,6 @@
 #include "boost/variant.hpp"
 #include "boost/variant/lambda_visitor.hpp"
 
-#include "class_a.h"
-#include "jobs.h"
 
 #include <iostream>
 #include <string>

--- a/test/lambda_test3.cpp
+++ b/test/lambda_test3.cpp
@@ -22,8 +22,6 @@
 #include "boost/variant/lambda_visitor.hpp"
 #include "boost/variant/multivisitors.hpp"
 
-#include "class_a.h"
-#include "jobs.h"
 
 #include <iostream>
 #include <string>

--- a/test/lambda_test3.cpp
+++ b/test/lambda_test3.cpp
@@ -1,6 +1,6 @@
 
 //-----------------------------------------------------------------------------
-// boost-libs variant/test/lambda_test2.cpp source file
+// boost-libs variant/test/lambda_test3.cpp source file
 // See http://www.boost.org for updates, documentation, and revision history.
 //-----------------------------------------------------------------------------
 //
@@ -94,22 +94,22 @@ void run()
    static_assert(boost::is_same<typename decltype(ts)::return_type, types_t>::value, "Return type is incorrect");
 
 
-   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iiii);
-   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iiid);
-   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iidi);
-   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iidd);
-   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == idii);
-   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == idid);
-   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iddi);
-   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iddd);
-   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == diii);
-   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == diid);
-   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == didi);
-   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == didd);
-   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == ddii);
-   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == ddid);
-   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == dddi);
-   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == dddd);
+   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iiii);
+   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iiid);
+   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iidi);
+   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iidd);
+   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == idii);
+   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == idid);
+   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iddi);
+   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == iddd);
+   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == diii);
+   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == diid);
+   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == didi);
+   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == didd);
+   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == ddii);
+   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == ddid);
+   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == dddi);
+   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v4) == dddd);
 
 }
 

--- a/test/lambda_test3.cpp
+++ b/test/lambda_test3.cpp
@@ -1,0 +1,124 @@
+
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/lambda_test2.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Copyright (c) 2015
+// Klemens Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost/config.hpp"
+
+#ifdef BOOST_MSVC
+#pragma warning(disable:4244) // conversion from const int to const short
+#endif
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant.hpp"
+#include "boost/variant/lambda_visitor.hpp"
+#include "boost/variant/multivisitors.hpp"
+
+#include "class_a.h"
+#include "jobs.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+
+void run()
+{
+
+   using boost::apply_visitor;
+   using boost::variant;
+   using std::string;
+   using std::vector;
+   using std::cout;
+   using std::endl;
+   using std::nullptr_t;
+
+   typedef variant< int, double > t_var;
+
+
+   t_var v1, v2, v3, v4;
+
+
+
+   enum types_t
+   {
+	   iiii,
+	   iiid,
+	   iidi,
+	   iidd,
+	   idii,
+	   idid,
+	   iddi,
+	   iddd,
+	   diii,
+	   diid,
+	   didi,
+	   didd,
+	   ddii,
+	   ddid,
+	   dddi,
+	   dddd,
+   };
+
+   //
+   //Very basic, btu if the thing works, i would consider my the lambda visitor to work.
+   //
+
+   using dbl = double;
+
+   auto ts = boost::make_lambda_visitor(
+		   [](int, int, int, int)	{return iiii;},
+		   [](int, int, int, dbl)	{return iiid;},
+		   [](int, int, dbl, int)	{return iidi;},
+		   [](int, int, dbl, dbl)	{return iidd;},
+		   [](int, dbl, int, int)	{return idii;},
+		   [](int, dbl, int, dbl)	{return idid;},
+		   [](int, dbl, dbl, int)	{return iddi;},
+		   [](int, dbl, dbl, dbl)	{return iddd;},
+		   [](dbl, int, int, int)	{return diii;},
+		   [](dbl, int, int, dbl)	{return diid;},
+		   [](dbl, int, dbl, int)	{return didi;},
+		   [](dbl, int, dbl, dbl)	{return didd;},
+		   [](dbl, dbl, int, int)	{return ddii;},
+		   [](dbl, dbl, int, dbl)	{return ddid;},
+		   [](dbl, dbl, dbl, int)	{return dddi;},
+		   [](dbl, dbl, dbl, dbl)	{return dddd;});
+
+   static_assert(boost::is_same<typename decltype(ts)::return_type, types_t>::value, "Return type is incorrect");
+
+
+   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iiii);
+   v1 = 0 ; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iiid);
+   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iidi);
+   v1 = 0 ; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iidd);
+   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == idii);
+   v1 = 0 ; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == idid);
+   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iddi);
+   v1 = 0 ; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == iddd);
+   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == diii);
+   v1 = 0.; v2 = 0 ; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == diid);
+   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == didi);
+   v1 = 0.; v2 = 0 ; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == didd);
+   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == ddii);
+   v1 = 0.; v2 = 0.; v3 = 0 ; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == ddid);
+   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0 ;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == dddi);
+   v1 = 0.; v2 = 0.; v3 = 0.; v4 = 0.;    BOOST_CHECK(apply_visitor(ts, v1, v2, v3, v3) == dddd);
+
+}
+
+
+
+int test_main(int , char* [])
+{
+   run();
+   return 0;
+}

--- a/test/lambda_test4.cpp
+++ b/test/lambda_test4.cpp
@@ -1,0 +1,69 @@
+
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/lambda_test4.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Copyright (c) 2015
+// Klemens Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost/config.hpp"
+
+#ifdef BOOST_MSVC
+#pragma warning(disable:4244) // conversion from const int to const short
+#endif
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant.hpp"
+#include "boost/variant/lambda_visitor.hpp"
+#include "boost/variant/multivisitors.hpp"
+
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+
+
+void run4()
+{
+
+   using boost::apply_visitor;
+   using boost::variant;
+   using std::string;
+   using std::vector;
+   using std::cout;
+   using std::endl;
+   using std::nullptr_t;
+
+   typedef variant< int, double > t_var;
+
+
+   t_var v;
+
+
+
+
+   //test the function for void and not void
+
+   double d = 0;
+   v = 3.124;
+
+   boost::apply_lambdas(v, [&](double din) {d = din;}, [&](int in){});
+   BOOST_CHECK(d == 3.124);
+
+   v = 42;
+   int i = boost::apply_lambdas(v, [&](double din)->int {return din;}, [&](int in){return in;});
+   BOOST_CHECK(i == 42);
+
+
+
+}
+
+
+
+

--- a/test/lambda_test4.cpp
+++ b/test/lambda_test4.cpp
@@ -40,27 +40,70 @@ void run4()
    using std::endl;
    using std::nullptr_t;
 
-   typedef variant< int, double > t_var;
+   typedef variant< int, double > t_var1;
+   typedef variant<int, double, unsigned, char> t_var2;
 
 
-   t_var v;
-
-
-
+   t_var1 v1;
 
    //test the function for void and not void
 
    double d = 0;
-   v = 3.124;
+   v1 = 3.124;
 
-   boost::apply_lambdas(v, [&](double din) {d = din;}, [&](int in){});
+   boost::apply_lambdas(v1, [&](double din) {d = din;}, [&](int in){});
    BOOST_CHECK(d == 3.124);
 
-   v = 42;
-   int i = boost::apply_lambdas(v, [&](double din)->int {return din;}, [&](int in){return in;});
+   v1 = 42;
+   int i = boost::apply_lambdas(v1, [&](double din)->int {return din;}, [&](int in){return in;});
    BOOST_CHECK(i == 42);
 
 
+   //check the generic lambda
+
+    auto gen_vis = make_lambda_visitor<string>(
+ 		   	   [](auto val){return to_string(val);});
+
+    t_var2 v2;
+
+    v2 = 'a';
+    BOOST_CHECK(apply_visitor(gen_vis, v2) == to_string('a'));
+
+    v2 = 42u;
+    BOOST_CHECK(apply_visitor(gen_vis, v2) == to_string(42u));
+
+    v2 = 3.12;
+    BOOST_CHECK(apply_visitor(gen_vis, v2) == to_string(3.12));
+
+    v2 = -10;
+    BOOST_CHECK(apply_visitor(gen_vis, v2) == to_string(-10));
+
+
+    //look if the generic lambda is overloadable
+
+    v2 = 42u;
+
+    bool called_auto = false;
+    bool called_unsigned = false;
+    apply_lambdas<void>(v2, [&](auto v2){called_auto = true;}, [&](unsigned u){called_unsigned = true;});
+
+    BOOST_CHECK(!called_auto);
+    BOOST_CHECK(called_unsigned);
+
+
+    enum tp
+    {
+ 	   is_auto, is_double
+    };
+
+    v2 = 3.4;
+
+    BOOST_CHECK(apply_lambdas<tp>(v2, [](double ){return is_double;}, [](auto) {return is_auto;}) == is_double);
+
+
+    v2 = 42;
+
+    BOOST_CHECK(apply_lambdas<tp>(v2, [](double ){return is_double;}, [](auto) {return is_auto;}) == is_auto);
 
 }
 


### PR DESCRIPTION
This is a little utility I built for one of my projects and I thought it might be interesting for the library. It allows a very short syntax to get the value of a variant by using lambdas. That could look like:

`variant<int, string> var;
auto vis = make_lambda_visitor([](int){...}, [](string){...});
var.apply_visitor(vis);`

The whole thing works and though it is names lambda-visitor it should work with all functors.
Since it has to deduce the return type of the call, it cannot use generic lambdas, even if that would be nice. That could be added, by deducing the return type from the first lambda so that a look-up does not happen for the latter ones. Atm all lambdas are checked by static_assert if the return types fit.