### PR TITLE
Include type_traits/remove_cv.hpp

### DIFF
--- a/include/boost/variant/detail/element_index.hpp
+++ b/include/boost/variant/detail/element_index.hpp
@@ -17,6 +17,7 @@
 #include "boost/variant/variant_fwd.hpp"
 
 #include "boost/mpl/find_if.hpp"
+#include "boost/type_traits/remove_cv.hpp"
 
 namespace boost { namespace detail { namespace variant {
 


### PR DESCRIPTION
Include type_traits/remove_cv.hpp in boost/variant/detail/element_index.hpp. Otherwise including <boost/variant/get.hpp> before or without other headers will generate compile errors.