### PR TITLE
Workaround for Oracle C++ compiler

### DIFF
--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -1352,7 +1352,10 @@ public: // structors
         destroy_content();
     }
 
-    variant() BOOST_NOEXCEPT_IF(boost::has_nothrow_constructor<internal_T0>::value)
+    variant() 
+#if !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5130))
+              BOOST_NOEXCEPT_IF(boost::has_nothrow_constructor<internal_T0>::value)
+#endif
     {
 #ifdef _MSC_VER
 #pragma warning( push )


### PR DESCRIPTION
This change reduces the number of Variant test failures from 23 to 6 when building with the Oracle compiler, and at least gets simple usage working.

I could also fix this by disabling conditional noexcept support in Config, but since it seems to be mostly working otherwise, that seems to be a shame.