### PR TITLE
Missing include in recursive_wrapper_fwd.hpp.

### DIFF
--- a/include/boost/variant/recursive_wrapper_fwd.hpp
+++ b/include/boost/variant/recursive_wrapper_fwd.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOST_VARIANT_RECURSIVE_WRAPPER_FWD_HPP
 #define BOOST_VARIANT_RECURSIVE_WRAPPER_FWD_HPP
 
+#include <boost/mpl/bool.hpp>
 #include "boost/mpl/aux_/config/ctps.hpp"
 #include "boost/mpl/aux_/lambda_support.hpp"
 #include <boost/type_traits/integral_constant.hpp>


### PR DESCRIPTION
Add a missing include for mpl::true_/false_.
Compiling
```C++
#include <boost/variant/recursive_wrapper.hpp>
int main() { }
```
with GCC gives
```
In file included from boost_1_60_0/boost/variant/recursive_wrapper.hpp:16:0,
                 from test.cpp:1:
boost_1_60_0/boost/variant/recursive_wrapper_fwd.hpp:54:1: error: expected class-name before ‘{’ token
 {
 ^
boost_1_60_0/boost/variant/recursive_wrapper_fwd.hpp:60:1: error: expected class-name before ‘{’ token
 {
 ^
```