### PR TITLE
Typos in Documentation

### DIFF
--- a/doc/reference/get.xml
+++ b/doc/reference/get.xml
@@ -16,13 +16,13 @@
       </inherit>
 
       <purpose>
-        <simpara>The exception thrown in	the	event	of a failed application of
-        <code><functionname>boost::get</functionname></code> on	the given
+        <simpara>The exception thrown in the event of a failed application of
+        <code><functionname>boost::get</functionname></code> on the given
         operand value.</simpara>
       </purpose>
 
-      <method	name="what"	specifiers="virtual" cv="const">
-        <type>const	char *</type>
+      <method name="what" specifiers="virtual" cv="const">
+        <type>const char *</type>
       </method>
     </class>
 

--- a/doc/reference/get.xml
+++ b/doc/reference/get.xml
@@ -107,7 +107,7 @@
         <simpara><emphasis role="bold">Recomendation</emphasis>: Use
           <functionname>get</functionname> or <functionname>strict_get</functionname> in new code.
           <functionname>strict_get</functionname>
-          provides more compile time checks and it's behavior is closer to <code>std::get</code>
+          provides more compile time checks and its behavior is closer to <code>std::get</code>
           from C++ Standard Library.</simpara>
         <simpara><emphasis role="bold">Warning</emphasis>: After either
           <code>operand</code> or its content is destroyed (e.g., when the
@@ -309,7 +309,7 @@
         <simpara><emphasis role="bold">Recomendation</emphasis>: Use
           <functionname>get</functionname> in new code without defining
           <code>BOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT</code>. In that way <functionname>get</functionname>
-          provides more compile time checks and it's behavior is closer to <code>std::get</code>
+          provides more compile time checks and its behavior is closer to <code>std::get</code>
           from C++ Standard Library.</simpara>
       </description>
     </overloaded-function>

--- a/doc/reference/polymorphic_get.xml
+++ b/doc/reference/polymorphic_get.xml
@@ -17,12 +17,12 @@
 
       <purpose>
         <simpara>The exception thrown in the event of a failed application of
-        <code><functionname>boost::polymorphic_get</functionname></code> on	the given
+        <code><functionname>boost::polymorphic_get</functionname></code> on the given
         operand value.</simpara>
       </purpose>
 
-      <method	name="what"	specifiers="virtual" cv="const">
-        <type>const	char *</type>
+      <method name="what" specifiers="virtual" cv="const">
+        <type>const char *</type>
       </method>
     </class>
 

--- a/doc/reference/polymorphic_get.xml
+++ b/doc/reference/polymorphic_get.xml
@@ -109,7 +109,7 @@
           <functionname>polymorphic_get</functionname> or <functionname>polymorphic_strict_get</functionname>
           in new code.
           <functionname>polymorphic_strict_get</functionname>
-          provides more compile time checks and it's behavior is closer to <code>std::get</code>
+          provides more compile time checks and its behavior is closer to <code>std::get</code>
           from C++ Standard Library.</simpara>
         <simpara><emphasis role="bold">Warning</emphasis>: After either
           <code>operand</code> or its content is destroyed (e.g., when the
@@ -318,7 +318,7 @@
           <functionname>polymorphic_get</functionname> in new code without defining
           <code>BOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT</code>. In that way
           <functionname>polymorphic_get</functionname>
-          provides more compile time checks and it's behavior is closer to <code>std::get</code>
+          provides more compile time checks and its behavior is closer to <code>std::get</code>
           from C++ Standard Library.</simpara>
       </description>
     </overloaded-function>


### PR DESCRIPTION
I noticed some minor typos in the documentation of boost::variant and fixed them.