### PR TITLE
Suppress implicit instantiation of MPL end iterator

### DIFF
--- a/include/boost/variant/detail/visitation_impl.hpp
+++ b/include/boost/variant/detail/visitation_impl.hpp
@@ -258,7 +258,7 @@ visitation_impl(
     typedef typename is_same< next_type,apply_visitor_unrolled >::type
         is_apply_visitor_unrolled;
 
-    return visitation_impl(
+    return detail::variant::visitation_impl(
           internal_which, logical_which
         , visitor, storage
         , is_apply_visitor_unrolled()


### PR DESCRIPTION
This change suppress implicit instantiation of MPL end iterator in the code using `boost::make_variant_over` with some MPL sequence.
Some of the MPL iterators (for instance, boost::fusion::vector's iterator) can not be used as complete type.
Therefore, `make_variant_over` with such an iterator results in a compile error.

```cpp
#include <boost/fusion/container/vector.hpp>
#include <boost/fusion/mpl.hpp>
#include <boost/variant/variant.hpp>

int main()
{
    boost::make_variant_over<boost::fusion::vector<int, char>>::type t{};
}
```

This change fix the issue by avoiding the template implicit instantiation due to ADL.
