### PR TITLE
Add preprocessor conditional BOOT_VARIANT_NO_TYPE_INDEX to remove typ…

### DIFF
--- a/include/boost/variant/bad_visit.hpp
+++ b/include/boost/variant/bad_visit.hpp
@@ -13,7 +13,9 @@
 #ifndef BOOST_VARIANT_BAD_VISIT_HPP
 #define BOOST_VARIANT_BAD_VISIT_HPP
 
+#ifndef BOOST_NO_EXCEPTIONS
 #include <exception>
+#endif
 
 namespace boost {
 
@@ -24,8 +26,11 @@ namespace boost {
 // to invalid visited subtype or contents.
 //
 struct bad_visit
+#ifndef BOOST_NO_EXCEPTIONS
     : std::exception
+#endif
 {
+#ifndef BOOST_NO_EXCEPTIONS
 public: // std::exception interface
 
     virtual const char * what() const BOOST_NOEXCEPT_OR_NOTHROW
@@ -33,7 +38,7 @@ public: // std::exception interface
         return "boost::bad_visit: "
                "failed visitation using boost::apply_visitor";
     }
-
+#endif
 };
 
 } // namespace boost

--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -13,7 +13,9 @@
 #ifndef BOOST_VARIANT_GET_HPP
 #define BOOST_VARIANT_GET_HPP
 
+#ifndef BOOST_NO_EXCEPTIONS
 #include <exception>
+#endif
 
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -18,7 +18,9 @@
 #include <cstddef> // for std::size_t
 #include <new> // for placement new
 
+#ifndef BOOST_VARIANT_NO_TYPE_INDEX
 #include <boost/type_index.hpp>
+#endif
 
 #include <boost/variant/detail/config.hpp>
 #include <boost/mpl/aux_/value_wknd.hpp>
@@ -928,6 +930,7 @@ private:
 // Generic static visitor that performs a typeid on the value it visits.
 //
 
+#ifndef BOOST_VARIANT_NO_TYPE_INDEX
 class reflect
     : public static_visitor<const boost::typeindex::type_info&>
 {
@@ -940,6 +943,7 @@ public: // visitor interfaces
     }
 
 };
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // (detail) class comparer
@@ -2251,11 +2255,13 @@ public: // queries
         return false;
     }
 
+#ifndef BOOST_VARIANT_NO_TYPE_INDEX
     const boost::typeindex::type_info& type() const
     {
         detail::variant::reflect visitor;
         return this->apply_visitor(visitor);
     }
+#endif
 
 public: // prevent comparison with foreign types
 


### PR DESCRIPTION
…e_index dependency

This is useful in targets without RTTI and which won't use type_index features. e.g. AVR 8-bit CPUs (Arduinos).