### PR TITLE
Solution for ticket 13037

### DIFF
--- a/include/boost/variant/polymorphic_get.hpp
+++ b/include/boost/variant/polymorphic_get.hpp
@@ -25,6 +25,7 @@
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/add_pointer.hpp>
 #include <boost/type_traits/is_base_of.hpp>
+#include <boost/type_traits/is_const.hpp>
 
 namespace boost {
 


### PR DESCRIPTION
https://svn.boost.org/trac/boost/ticket/13037

Missing include of `<boost/type_traits/is_const.hpp>` added in `<boost/variant/polymorphic_get.hpp>`.

_Note however that it seems `polymorphic_get.hpp` header has more such issues: use of elements that are not directly included. Among others there is `boost::remove_cv` - a problem mentioned in [ticket 11283](https://svn.boost.org/trac/boost/ticket/11283). Should they be solved as well? At least as for now they are not causing compilation errors._