### PR TITLE
Add rvalue get<>() support + tests.

### DIFF
--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -28,8 +28,6 @@
 #include <boost/type_traits/add_pointer.hpp>
 #include <boost/type_traits/is_lvalue_reference.hpp>
 
-#include <boost/mpl/not.hpp>
-
 namespace boost {
 
 #if defined(BOOST_CLANG)
@@ -273,7 +271,7 @@ strict_get(
     )
 {
     BOOST_STATIC_ASSERT_MSG(
-        (mpl::not_< boost::is_lvalue_reference<U> >::value),
+        (!boost::is_lvalue_reference<U>::value),
         "remove ampersand '&' from template type U in boost::get<U>(boost::variant<T...>&&) "
     );
 

--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -22,6 +22,7 @@
 #include <boost/utility/addressof.hpp>
 #include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/detail/element_index.hpp>
+#include <boost/variant/detail/move.hpp>
 
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/add_pointer.hpp>
@@ -170,7 +171,23 @@ relaxed_get(
     return *result;
 }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+template <typename U, BOOST_VARIANT_ENUM_PARAMS(typename T) >
+inline
+    U&&
+relaxed_get(
+      boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >&& operand
+      BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(U)
+    )
+{
+    typedef typename add_pointer<U>::type U_ptr;
+    U_ptr result = relaxed_get<U>(boost::addressof(operand));
 
+    if (!result)
+        boost::throw_exception(bad_get());
+    return detail::variant::move(*result);
+}
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // strict_get<U>(variant) methods
@@ -243,6 +260,25 @@ strict_get(
     return relaxed_get<U>(operand);
 }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+template <typename U, BOOST_VARIANT_ENUM_PARAMS(typename T) >
+inline
+    U&&
+strict_get(
+      boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >&& operand
+      BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(U)
+    )
+{
+    BOOST_STATIC_ASSERT_MSG(
+        (boost::detail::variant::holds_element<boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >, U >::value),
+        "boost::variant does not contain specified type U, "
+        "call to boost::get<U>(const boost::variant<T...>&) will always throw boost::bad_get exception"
+    );
+
+    return relaxed_get<U>(detail::variant::move(operand));
+}
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // get<U>(variant) methods
 //
@@ -307,6 +343,23 @@ get(
     return strict_get<U>(operand);
 #endif
 }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+template <typename U, BOOST_VARIANT_ENUM_PARAMS(typename T) >
+inline
+    U&&
+get(
+      boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >&& operand
+      BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(U)
+    )
+{
+#ifdef BOOST_VARIANT_USE_RELAXED_GET_BY_DEFAULT
+    return relaxed_get<U>(detail::variant::move(operand));
+#else
+    return strict_get<U>(detail::variant::move(operand));
+#endif
+}
+#endif
 
 } // namespace boost
 

--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -26,6 +26,9 @@
 
 #include <boost/type_traits/add_reference.hpp>
 #include <boost/type_traits/add_pointer.hpp>
+#include <boost/type_traits/is_lvalue_reference.hpp>
+
+#include <boost/mpl/not.hpp>
 
 namespace boost {
 
@@ -185,7 +188,7 @@ relaxed_get(
 
     if (!result)
         boost::throw_exception(bad_get());
-    return detail::variant::move(*result);
+    return static_cast<U&&>(*result);
 }
 #endif
 
@@ -269,6 +272,11 @@ strict_get(
       BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(U)
     )
 {
+    BOOST_STATIC_ASSERT_MSG(
+        (mpl::not_< boost::is_lvalue_reference<U> >::value),
+        "remove ampersand '&' from template type U in boost::get<U>(boost::variant<T...>&&) "
+    );
+
     BOOST_STATIC_ASSERT_MSG(
         (boost::detail::variant::holds_element<boost::variant< BOOST_VARIANT_ENUM_PARAMS(T) >, U >::value),
         "boost::variant does not contain specified type U, "

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,13 +6,12 @@
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt) #
-
+#
 project
     : requirements
         #<dependency>/boost/test//minimal
         <toolset>msvc:<asynch-exceptions>on
     ;
-
 test-suite variant
      :
     [ run test1.cpp class_a.cpp : : : : variant_test1 ]

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,7 +5,7 @@
 #
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt) #
+# http://www.boost.org/LICENSE_1_0.txt)
 #
 project
     : requirements

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -5,21 +5,21 @@
 #
 # Use, modification and distribution is subject to the Boost Software License,
 # Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
-# http://www.boost.org/LICENSE_1_0.txt)
-#
+# http://www.boost.org/LICENSE_1_0.txt) #
+
 project
     : requirements
         #<dependency>/boost/test//minimal
         <toolset>msvc:<asynch-exceptions>on
     ;
-    
+
 test-suite variant
-     : 
+     :
     [ run test1.cpp class_a.cpp : : : : variant_test1 ]
     [ run test2.cpp : : : : variant_test2 ]
     [ run test3.cpp : : : : variant_test3 ]
     [ run test3.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : variant_test3_no_rtti ]
-    [ run test4.cpp class_a.cpp 
+    [ run test4.cpp class_a.cpp
         : : : : variant_test4 ]
     [ run test5.cpp : : : : variant_test5 ]
     [ run test6.cpp : : : : variant_test6 ]
@@ -31,6 +31,7 @@ test-suite variant
     [ run variant_comparison_test.cpp ]
     [ run variant_visit_test.cpp ]
     [ run variant_get_test.cpp ]
+    [ compile-fail variant_rvalue_get_with_ampersand_test.cpp ]
     [ run variant_polymorphic_get_test.cpp ]
     [ run variant_multivisit_test.cpp ]
     [ run hash_variant_test.cpp ]
@@ -52,6 +53,6 @@ test-suite variant
     [ run auto_visitors.cpp ]
     [ run overload_selection.cpp ]
     [ run recursive_wrapper_move_test.cpp ]
-   ; 
+   ;
 
 

--- a/test/variant_get_test.cpp
+++ b/test/variant_get_test.cpp
@@ -381,7 +381,7 @@ inline void get_rvref_test()
   boost::variant<MoveonlyType, int> v;
 
   v = MoveonlyType();
-  MoveonlyType&& mt1 = boost::get<MoveonlyType>(boost::move(v));
+  boost::get<MoveonlyType>(boost::move(v));
 
   v = 3;
 

--- a/test/variant_get_test.cpp
+++ b/test/variant_get_test.cpp
@@ -367,19 +367,31 @@ public:
 
 private:
     MoveonlyType(const MoveonlyType&);
-    MoveonlyType(MoveonlyType&&);
+    void operator=(const MoveonlyType& other);
 };
+
+const boost::variant<int, std::string> foo1() { return ""; }
+boost::variant<int, std::string> foo2() { return ""; }
 
 inline void get_rvref_test()
 {
-  boost::variant<int, MoveonlyType> v;
+  boost::get<std::string>(foo1());
+  boost::get<std::string>(foo2());
+
+  boost::variant<MoveonlyType, int> v;
+
   v = MoveonlyType();
-  BOOST_CHECK(boost::get<MoveonlyType>(boost::move(v)));
-  BOOST_CHECK(boost::get<MoveonlyType>(v));
+  MoveonlyType&& mt1 = boost::get<MoveonlyType>(boost::move(v));
 
-  boost::relaxed_get<MoveonlyType&>(boost::variant<int, MoveonlyType>()) // Must compile
+  v = 3;
 
-  MoveonlyType moved_from_variant(boost::get<MoveonlyType>(boost::move(x)));
+  v = MoveonlyType();
+  boost::get<MoveonlyType>(v);
+
+  boost::relaxed_get<MoveonlyType&>(boost::variant<MoveonlyType, int>());
+
+  v = MoveonlyType();
+  MoveonlyType moved_from_variant(boost::get<MoveonlyType>(boost::move(v)));
 }
 #endif  // BOOST_NO_CXX11_RVALUE_REFERENCES
 

--- a/test/variant_get_test.cpp
+++ b/test/variant_get_test.cpp
@@ -356,6 +356,33 @@ inline void check_that_does_not_exist()
     check_that_does_not_exist_impl<var_req_t>();
 }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+class MoveonlyType {
+public:
+    MoveonlyType() {}
+    ~MoveonlyType() {}
+
+    MoveonlyType(MoveonlyType&& other) {}
+    void operator=(MoveonlyType&& other) {}
+
+private:
+    MoveonlyType(const MoveonlyType&);
+    MoveonlyType(MoveonlyType&&);
+};
+
+inline void get_rvref_test()
+{
+  boost::variant<int, MoveonlyType> v;
+  v = MoveonlyType();
+  BOOST_CHECK(boost::get<MoveonlyType>(boost::move(v)));
+  BOOST_CHECK(boost::get<MoveonlyType>(v));
+
+  boost::relaxed_get<MoveonlyType&>(boost::variant<int, MoveonlyType>()) // Must compile
+
+  MoveonlyType moved_from_variant(boost::get<MoveonlyType>(boost::move(x)));
+}
+#endif  // BOOST_NO_CXX11_RVALUE_REFERENCES
+
 int test_main(int , char* [])
 {
     get_test();
@@ -364,6 +391,10 @@ int test_main(int , char* [])
     get_cref_test();
     get_recursive_test();
     check_that_does_not_exist();
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    get_rvref_test();
+#endif
 
     return boost::exit_success;
 }

--- a/test/variant_rvalue_get_with_ampersand_test.cpp
+++ b/test/variant_rvalue_get_with_ampersand_test.cpp
@@ -3,7 +3,7 @@
 // See http://www.boost.org for updates, documentation, and revision history.
 //-----------------------------------------------------------------------------
 //
-// Copyright (c) 2014-2017 Antony Polukhin
+// Copyright (c) 2017-2017 Albert Sverdlov
 //
 // Distributed under the Boost Software License, Version 1.0. (See
 // accompanying file LICENSE_1_0.txt or copy at

--- a/test/variant_rvalue_get_with_ampersand_test.cpp
+++ b/test/variant_rvalue_get_with_ampersand_test.cpp
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/variant_get_test.cpp source file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Copyright (c) 2014-2017 Antony Polukhin
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#include "boost/variant/get.hpp"
+#include "boost/variant/variant.hpp"
+#include "boost/test/minimal.hpp"
+
+#include <boost/move/move.hpp>
+#include <boost/static_assert.hpp>
+
+#include <string>
+
+#define UNUSED(v) (void)(v)
+
+inline void run()
+{
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    typedef boost::variant<int, std::string> var_t;
+
+    std::string s = "abacaba";
+    var_t v = s;
+
+    // must spit an error at compile-time because of 'std::string&'
+    std::string new_s = boost::strict_get<std::string&>(boost::move(v));
+    UNUSED(new_s);
+#else
+    BOOST_STATIC_ASSERT_MSG(false, "Dummy compile-time error to pass the test on C++03");
+#endif
+}
+
+int test_main(int /*argc*/, char* /*argv*/ [])
+{
+    run();
+    return boost::exit_success;
+}


### PR DESCRIPTION
This PR adds rvalue version of get<>().
Tests for expected behaviour and compile errors are added.
Ticket: https://svn.boost.org/trac/boost/ticket/13018.