### PR TITLE
Fix joint view

### DIFF
--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -71,12 +71,13 @@
 #include <boost/mpl/front.hpp>
 #include <boost/mpl/identity.hpp>
 #include <boost/mpl/if.hpp>
+#include <boost/mpl/insert_range.hpp>
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/is_sequence.hpp>
 #include <boost/mpl/iterator_range.hpp>
 #include <boost/mpl/iter_fold_if.hpp>
-#include <boost/mpl/logical.hpp>
 #include <boost/mpl/list.hpp>
+#include <boost/mpl/logical.hpp>
 #include <boost/mpl/max_element.hpp>
 #include <boost/mpl/next.hpp>
 #include <boost/mpl/not.hpp>
@@ -87,8 +88,6 @@
 #include <boost/mpl/size_t.hpp>
 #include <boost/mpl/sizeof.hpp>
 #include <boost/mpl/transform.hpp>
-#include <boost/mpl/vector.hpp>
-#include <boost/mpl/copy.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementation Macros:
@@ -2455,7 +2454,11 @@ struct make_variant_over
 private: // precondition assertions
 
     BOOST_STATIC_ASSERT(( ::boost::mpl::is_sequence<Types>::value ));
-    typedef typename mpl::copy<Types, boost::mpl::front_inserter<mpl::list<> > >::type copied_sequence_t;
+    typedef typename boost::mpl::insert_range<
+      boost::mpl::list<>
+    , boost::mpl::end< boost::mpl::list<> >::type
+    , Types
+    >::type copied_sequence_t;
 
 public: // metafunction result
 

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -76,6 +76,7 @@
 #include <boost/mpl/iterator_range.hpp>
 #include <boost/mpl/iter_fold_if.hpp>
 #include <boost/mpl/logical.hpp>
+#include <boost/mpl/list.hpp>
 #include <boost/mpl/max_element.hpp>
 #include <boost/mpl/next.hpp>
 #include <boost/mpl/not.hpp>
@@ -2454,7 +2455,7 @@ struct make_variant_over
 private: // precondition assertions
 
     BOOST_STATIC_ASSERT(( ::boost::mpl::is_sequence<Types>::value ));
-    typedef typename mpl::copy<Types, boost::mpl::back_inserter<mpl::vector<> > >::type copied_sequence_t;
+    typedef typename mpl::copy<Types, boost::mpl::front_inserter<mpl::list<> > >::type copied_sequence_t;
 
 public: // metafunction result
 
@@ -2470,7 +2471,7 @@ public: // metafunction result
 template <typename... Types>
 struct make_variant_over< mpl::vector<Types...> > {
   private: // precondition assertions
-  typedef mpl::vector<Types...> sequence_t;
+  typedef mpl::list<Types...> sequence_t;
 
   public: // metafunction result
   typedef variant<

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -2465,24 +2465,6 @@ public: // metafunction result
 
 };
 
-#ifndef BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES
-
-// Optimizing compilation speed by avoiding MPL computations for the most common case
-template <typename... Types>
-struct make_variant_over< mpl::vector<Types...> > {
-  private: // precondition assertions
-  typedef mpl::list<Types...> sequence_t;
-
-  public: // metafunction result
-  typedef variant<
-    detail::variant::over_sequence<sequence_t>
-  > type;
-
-};
-
-#endif // #ifndef BOOST_VARIANT_DO_NOT_USE_VARIADIC_TEMPLATES
-
-
 ///////////////////////////////////////////////////////////////////////////////
 // function template swap
 //

--- a/test/variant_over_joint_view_test.cpp
+++ b/test/variant_over_joint_view_test.cpp
@@ -23,7 +23,7 @@ void check_exception_on_get(Variant& v) {
     try {
         boost::get<T>(v);
         BOOST_FAIL("Expected exception boost::bad_get, but got nothing.");
-    } catch (boost::bad_get& exc) { //okay it is expected behaviour
+    } catch (boost::bad_get&) { //okay it is expected behaviour
     } catch (...) { BOOST_FAIL("Expected exception boost::bad_get, but got something else."); }
 }
 
@@ -36,8 +36,10 @@ void test_joint_view() {
     v2 b = "2";
     v3 c = a;
     BOOST_CHECK(boost::get<int>(c) == 1);
+    BOOST_CHECK(c.which() == 0);
     v3 d = b;
     BOOST_CHECK(boost::get<std::string>(d) == "2");
+    BOOST_CHECK(d.which() == 1);
     check_exception_on_get<std::string>(c);
     check_exception_on_get<int>(d);
 }


### PR DESCRIPTION
make_over_sequence works if use mpl::list instead of vector. Speeding up compilation using specification for mpl::vector<Args...> conflicts with old mpl::vector and does not work - so it was abandoned.