### PR TITLE
Perfect forwarding for passing visitor in apply_visitor.

### DIFF
--- a/include/boost/variant/detail/apply_visitor_unary.hpp
+++ b/include/boost/variant/detail/apply_visitor_unary.hpp
@@ -155,9 +155,9 @@ struct result_wrapper1
 {
     typedef decltype(result_multideduce1<Visitor, Variant>::deduce()) result_type;
 
-    Visitor& visitor_;
-    explicit result_wrapper1(Visitor& visitor) BOOST_NOEXCEPT
-        : visitor_(visitor)
+    Visitor&& visitor_;
+    explicit result_wrapper1(Visitor&& visitor) BOOST_NOEXCEPT
+        : visitor_(::boost::forward<Visitor>(visitor))
     {}
 
     template <class T>
@@ -169,25 +169,14 @@ struct result_wrapper1
 }} // namespace detail::variant
 
 template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(Visitor& visitor, Visitable&& visitable,
+inline decltype(auto) apply_visitor(Visitor&& visitor, Visitable&& visitable,
     typename boost::disable_if<
         boost::detail::variant::has_result_type<Visitor>
     >::type* = 0)
 {
-    boost::detail::variant::result_wrapper1<Visitor, typename remove_reference<Visitable>::type> cpp14_vis(visitor);
+    boost::detail::variant::result_wrapper1<Visitor, typename remove_reference<Visitable>::type> cpp14_vis(::boost::forward<Visitor>(visitor));
     return ::boost::forward<Visitable>(visitable).apply_visitor(cpp14_vis);
 }
-
-template <typename Visitor, typename Visitable>
-inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable&& visitable,
-    typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
-{
-    boost::detail::variant::result_wrapper1<const Visitor, typename remove_reference<Visitable>::type> cpp14_vis(visitor);
-    return ::boost::forward<Visitable>(visitable).apply_visitor(cpp14_vis);
-}
-
 
 #endif // !defined(BOOST_NO_CXX14_DECLTYPE_AUTO) && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
 

--- a/test/const_ref_apply_visitor.cpp
+++ b/test/const_ref_apply_visitor.cpp
@@ -190,6 +190,13 @@ void test_cpp14_visitor(const variant_type& test_var)
     BOOST_CHECK(boost::apply_visitor([](auto&& v) { return lvalue_rvalue_detector()(FORWARD(v)); }, test_var) == "lvalue reference");
 }
 
+void test_cpp14_mutable_visitor(const variant_type& test_var)
+{
+    std::cout << "Testing const lvalue visitable for c++14 with inline mutable lambda\n";
+
+    BOOST_CHECK(boost::apply_visitor([](auto&& v) mutable -> auto { return lvalue_rvalue_detector()(FORWARD(v)); }, test_var) == "lvalue reference");
+}
+
 void test_cpp14_visitor(const variant_type& test_var, const variant_type& test_var2)
 {
     std::cout << "Testing const lvalue visitable for c++14\n";
@@ -329,6 +336,7 @@ void run_cpp14_tests()
     variant_type v1(10), v2(20), v3(30);
 
     test_cpp14_visitor(v1);
+    test_cpp14_mutable_visitor(v1);
     test_cpp14_visitor(v2, v3);
     test_cpp14_visitor(v1, v2, v3);
 


### PR DESCRIPTION
Added apply_visitor with Visitor&&. Allows to bind Visitor&&, Visitor& and const Visitor&.
Removed apply_visitor with const Visitor& since it was catching inlined Visitors&&.
Passing const Visitor to result_wrapper resulted in compilation error when Visitor was mutable.

Fixes: https://github.com/boostorg/variant/issues/39