### PR TITLE
disambiguate class variant.

### DIFF
--- a/test/test7.cpp
+++ b/test/test7.cpp
@@ -220,7 +220,7 @@ void var_compare(const VariantType& v, ExpectedType expected)
 
 void run()
 {   
-   variant<string, short> v0;
+   boost::variant<string, short> v0;
 
    var_compare(v0, string(""));
 
@@ -230,7 +230,7 @@ void run()
    v0 = "penny lane";
    var_compare(v0, string("penny lane"));
 
-   variant<jas, string, int> v1, v2 = jas(195);
+   boost::variant<jas, string, int> v1, v2 = jas(195);
    var_compare(v1, jas(364));
 
    v1 = jas(500);
@@ -240,7 +240,7 @@ void run()
    var_compare(v2, jas(500));
 
 
-   variant<string, int> v3;
+   boost::variant<string, int> v3;
    var_compare(v3, string(""));
 }
 

--- a/test/test8.cpp
+++ b/test/test8.cpp
@@ -17,7 +17,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
 using namespace boost;
 
 typedef variant<float, std::string, int, std::vector<std::string> > t_var1;


### PR DESCRIPTION
When compiled with C++17 features enabled, class variant is defined in both namespace 'std' and namespace 'boost'.

Signed-off-by: Daniela Engert <dani@ngrt.de>