### PR TITLE
Rewrite the deduction of visitor return type

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -28,6 +28,11 @@ test-suite variant
     [ run recursive_variant_test.cpp ]
     [ run variant_reference_test.cpp ]
     [ run variant_comparison_test.cpp ]
+    [ run variant_visit_internal_linkage.cpp : : :
+      <toolset>darwin:<cxxflags>-std=c++14
+      : variant_visit_internal_linkage_test
+    ]
+
     [ run variant_visit_test.cpp ]
     [ run variant_get_test.cpp ]
     [ compile-fail variant_rvalue_get_with_ampersand_test.cpp ]

--- a/test/variant_visit_internal_linkage.cpp
+++ b/test/variant_visit_internal_linkage.cpp
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------------
+// boost-libs variant/test/variant_visit_internal_linkage.cpp header file
+// See http://www.boost.org for updates, documentation, and revision history.
+//-----------------------------------------------------------------------------
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+// This test checks that we can visit a variant containing a type that has
+// internal linkage (anonymous namespace).
+
+#include "boost/test/minimal.hpp"
+#include "boost/variant/variant.hpp"
+
+
+namespace {
+   struct Foo { };
+
+   struct Visitor {
+      void operator()(Foo const&) const { }
+   };
+}
+
+void run() {
+   boost::variant<Foo> v = Foo();
+   boost::apply_visitor(Visitor(), v);
+}
+
+int test_main(int, char**) {
+   run();
+   return 0;
+}


### PR DESCRIPTION
This avoids using `boost::declval` inside evaluated contexts, which is invalid and will actually be diagnosed [by compilers][1] when the type used inside `boost::declval` has internal linkage (such as an anonymous namespace).

[1]: https://bugs.llvm.org/show_bug.cgi?id=35842