### PR TITLE
recursive_wrapper move constructor pointer stealing

### DIFF
--- a/doc/design.xml
+++ b/doc/design.xml
@@ -30,6 +30,16 @@
         possibility of undefined <code>variant</code> content and the
         significant additional complexity-of-use attendant with such a
         possibility.</para>
+
+      <para>Note: The never-empty guarantee was designed before move semantics
+        were available and it is still in place with one exception of move
+        operations on <classname>variant</classname> which contains an active
+        value of recursive type. It was made because instead of a very cheap
+        pointer stealing the general procedure for throwing move operations
+        was applied. For migration purposes there is a compatibility macro
+        <macroname>BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING</macroname>
+        that reverts the previous behavior.
+      </para>
     </section>
 
     <section id="variant.design.never-empty.problem">

--- a/doc/reference/apply_visitor.xml
+++ b/doc/reference/apply_visitor.xml
@@ -367,6 +367,10 @@
         given <code>variant</code>.</simpara>
       </requires>
 
+      <!--expects--><requires>
+        <simpara><code>(!operand.empty() &amp;&amp; ...)</code>.</simpara>
+      </requires>
+
       <throws>
         <simpara>The overloads accepting operands throw only if the given
         visitor throws when applied. The overload accepting only a visitor

--- a/doc/reference/recursive_wrapper.xml
+++ b/doc/reference/recursive_wrapper.xml
@@ -212,6 +212,8 @@
           <description>
             <simpara>Returns <code>true</code> when <code>*this</code>
               contains a value.</simpara>
+            <simpara>Note: When <macroname>BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING</macroname>
+                compatibility macro is defined &ndash; always returns <code>false</code>.</simpara>
           </description>
 
           <throws>Will not throw.</throws>
@@ -309,4 +311,21 @@
     </class>
 
   </namespace>
+
+  <macro name="BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING">
+    <purpose>
+      <simpara>A backward-compatibility/migration macro for reverting to the
+        previous never-empty <code><classname>recursive_wrapper</classname></code>.</simpara>
+    </purpose>
+    <description>
+      <para>
+        Defining the macro disables <code><classname>recursive_wrapper</classname></code> pointer
+        stealing from an other <code><classname>recursive_wrapper</classname></code> on move
+        construction.
+      </para>
+      <para>
+        Not defined by default. Appeared in Boost 1.70.
+      </para>
+    </description>
+  </macro>
 </header>

--- a/doc/reference/recursive_wrapper.xml
+++ b/doc/reference/recursive_wrapper.xml
@@ -65,6 +65,10 @@
             concept.</simpara>
         </requires>
 
+        <!--ensures--><postconditions>
+          <simpara><code>!empty()</code>.</simpara>
+        </postconditions>
+
         <throws>
           <simpara>May fail with any exceptions arising from the default
             constructor of <code>T</code> or, in the event of
@@ -83,6 +87,14 @@
             <code>*this</code>.</simpara>
         </description>
 
+        <!--expects--><requires>
+          <simpara><code>other.empty()</code>.</simpara>
+        </requires>
+
+        <!--ensures--><postconditions>
+          <simpara><code>!empty()</code>.</simpara>
+        </postconditions>
+
         <throws>
           <simpara>May fail with any exceptions arising from the
             copy constructor of <code>T</code> or, in the event of
@@ -100,6 +112,10 @@
           <simpara>Copies <code>operand</code> into
             <code>*this</code>.</simpara>
         </description>
+
+        <!--ensures--><postconditions>
+          <simpara><code>!empty()</code>.</simpara>
+        </postconditions>
 
         <throws>
           <simpara>May fail with any exceptions arising from the
@@ -144,6 +160,11 @@
             concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
+          </requires>
+
           <throws>
             <simpara>May fail with any exceptions arising from the assignment
               operator of <code>T</code>.</simpara>
@@ -169,6 +190,10 @@
               concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code>.</simpara>
+          </requires>
+
           <throws>
             <simpara>May fail with any exceptions arising from the assignment
               operator of <code>T</code>.</simpara>
@@ -179,6 +204,19 @@
 
       <method-group name="queries">
 
+        <overloaded-method name="empty">
+          <signature cv="const">
+            <type>bool</type>
+          </signature>
+
+          <description>
+            <simpara>Returns <code>true</code> when <code>*this</code>
+              contains a value.</simpara>
+          </description>
+
+          <throws>Will not throw.</throws>
+        </overloaded-method>
+
         <overloaded-method name="get">
           <signature>
             <type>T &amp;</type>
@@ -186,6 +224,10 @@
           <signature cv="const">
             <type>const T &amp;</type>
           </signature>
+
+          <!--expects--><requires>
+            <simpara><code>!empty()</code>.</simpara>
+          </requires>
 
           <description>
             <simpara>Returns a reference to the content of

--- a/doc/reference/variant.xml
+++ b/doc/reference/variant.xml
@@ -508,14 +508,18 @@
         <method name="empty" cv="const">
           <type>bool</type>
 
-          <returns><itemizedlist>
-            <listitem><code>false</code>: when is not a recursive <code>variant
-              </code> &ndash; it always contains exactly one of its bounded types.
-              (See <xref linkend="variant.design.never-empty"/> for more
-              information.)</listitem>
-            <listitem><code>true</code>: when a recursive <code>variant</code>
-              value was moved out.</listitem>
-          </itemizedlist></returns>
+          <returns>
+            <itemizedlist>
+              <listitem><code>false</code>: when is not a recursive <code>variant
+                </code> &ndash; it always contains exactly one of its bounded types.
+                (See <xref linkend="variant.design.never-empty"/> for more
+                information.)</listitem>
+              <listitem><code>true</code>: when a recursive <code>variant</code>
+                value was moved out.</listitem>
+            </itemizedlist>
+            <simpara>Note: When <macroname>BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING</macroname>
+                compatibility macro is defined &ndash; always returns <code>false</code>.</simpara>
+          </returns>
 
           <rationale>
             <simpara>Facilitates generic compatibility with

--- a/doc/reference/variant.xml
+++ b/doc/reference/variant.xml
@@ -131,6 +131,11 @@
             <code>other</code>.</simpara>
         </postconditions>
         
+        <!--ensures--><postconditions>
+          <simpara><code>other.empty()</code> if <code>other</code> had an
+            active value of a recursive type.</simpara>
+        </postconditions>
+
         <throws>
           <simpara>May fail with any exceptions arising from the
             move constructor of <code>other</code>'s contained type.</simpara>
@@ -367,6 +372,11 @@
               destroying the previous content of <code>*this</code>.</simpara>
           </effects>
 
+          <!--ensures--><postconditions>
+            <simpara><code>rhs.empty()</code> if <code>rhs</code> had an
+              active value of a recursive type.</simpara>
+          </postconditions>
+
           <throws>
             <simpara>If the contained type of <code>rhs</code> is the same as
               the contained type of <code>*this</code>, then may fail with any
@@ -410,6 +420,10 @@
               resolution rules, destroying the previous content of
               <code>*this</code>.</simpara>
           </effects>
+
+          <!--ensures--><postconditions>
+            <simpara><code>!empty()</code>.</simpara>
+          </postconditions>
 
           <throws>
             <simpara>If the contained type of <code>*this</code> is
@@ -457,6 +471,10 @@
               <code>*this</code>(conversion is usually done via move construction).</simpara>
           </effects>
 
+          <!--ensures--><postconditions>
+            <simpara><code>!empty()</code>.</simpara>
+          </postconditions>
+
           <throws>
             <simpara>If the contained type of <code>*this</code> is
               <code>T</code>, then may fail with any exceptions arising from
@@ -490,12 +508,14 @@
         <method name="empty" cv="const">
           <type>bool</type>
 
-          <returns>
-            <simpara><code>false</code>: <code>variant</code> always contains
-              exactly one of its bounded types. (See
-              <xref linkend="variant.design.never-empty"/>
-              for more information.)</simpara>
-          </returns>
+          <returns><itemizedlist>
+            <listitem><code>false</code>: when is not a recursive <code>variant
+              </code> &ndash; it always contains exactly one of its bounded types.
+              (See <xref linkend="variant.design.never-empty"/> for more
+              information.)</listitem>
+            <listitem><code>true</code>: when a recursive <code>variant</code>
+              value was moved out.</listitem>
+          </itemizedlist></returns>
 
           <rationale>
             <simpara>Facilitates generic compatibility with
@@ -561,6 +581,11 @@
               concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
+          </requires>
+
           <returns>
             <simpara><code>true</code> if <code>which() == rhs.which()</code>
               <emphasis>and</emphasis>
@@ -612,6 +637,11 @@
               concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
+          </requires>
+
           <returns>
             <simpara><code>true</code> if <code>!(*this == rhs)</code>.</simpara>
           </returns>
@@ -656,6 +686,11 @@
               fulfill the requirements of the
               <conceptname>LessThanComparable</conceptname>
               concept.</simpara>
+          </requires>
+
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
           </requires>
 
           <returns>
@@ -709,6 +744,11 @@
               concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
+          </requires>
+
           <returns>
             <simpara>true if <code>rhs &lt; *this</code>.</simpara>
           </returns>
@@ -756,6 +796,11 @@
               concept.</simpara>
           </requires>
 
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
+          </requires>
+
           <returns>
             <simpara>true if <code>!(*this > rhs)</code>.</simpara>
           </returns>
@@ -801,6 +846,11 @@
               fulfill the requirements of the
               <conceptname>LessThanComparable</conceptname>
               concept.</simpara>
+          </requires>
+
+          <!--expects--><requires>
+            <simpara><code>!empty()</code> and <code>!rhs.empty()</code>.
+              </simpara>
           </requires>
 
           <returns>
@@ -876,6 +926,11 @@
           concept.</simpara>
       </requires>
 
+      <!--expects--><requires>
+        <simpara><code>!rhs.empty()</code>.
+          </simpara>
+      </requires>
+
       <effects>
         <simpara>Calls <code>out &lt;&lt; x</code>, where <code>x</code> is
           the content of <code>rhs</code>.</simpara>
@@ -910,6 +965,11 @@
           fulfill the requirements of the
           <link linkend="variant.concepts.hashable"><emphasis>Hashable</emphasis></link>
           concept.</simpara>
+      </requires>
+
+      <!--expects--><requires>
+        <simpara><code>!rhs.empty()</code>.
+          </simpara>
       </requires>
 
       <effects>

--- a/doc/tutorial/advanced.xml
+++ b/doc/tutorial/advanced.xml
@@ -229,10 +229,6 @@ public:
 
   </para>
 
-  <para><emphasis role="bold">Performance</emphasis>: <classname>boost::recursive_wrapper</classname>
-    has no empty state, which makes its move constructor not very optimal. Consider using <code>std::unique_ptr</code> 
-    or some other safe pointer for better performance on C++11 compatible compilers.</para>
-
 </section>
 
 <section id="variant.tutorial.recursive.recursive-variant">

--- a/doc/tutorial/advanced.xml
+++ b/doc/tutorial/advanced.xml
@@ -229,6 +229,11 @@ public:
 
   </para>
 
+  <para><emphasis role="bold">Performance</emphasis>: <classname>boost::recursive_wrapper</classname>
+    will never be empty when <macroname>BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING</macroname> is defined,
+    what makes its move constructor not optimal even when a wrapped type has non-throwing move constructor.
+    Consider using <code>std::unique_ptr</code> or some other safe pointer for better performance on C++11 compatible compilers.</para>
+
 </section>
 
 <section id="variant.tutorial.recursive.recursive-variant">

--- a/include/boost/variant/recursive_wrapper.hpp
+++ b/include/boost/variant/recursive_wrapper.hpp
@@ -95,7 +95,11 @@ public: // modifiers
 
 public: // queries
 
+#ifndef BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING
     bool empty() const BOOST_NOEXCEPT { return get_pointer() == NULL; }
+#else
+    bool empty() const BOOST_NOEXCEPT { return false; }
+#endif
 
     // Expects: `!empty()`.
     T& get() BOOST_NOEXCEPT { BOOST_ASSERT(!empty()); return *get_pointer(); }

--- a/include/boost/variant/recursive_wrapper.hpp
+++ b/include/boost/variant/recursive_wrapper.hpp
@@ -16,6 +16,7 @@
 #include <boost/variant/recursive_wrapper_fwd.hpp>
 #include <boost/variant/detail/move.hpp>
 #include <boost/checked_delete.hpp>
+#include <boost/core/exchange.hpp>
 
 namespace boost {
 
@@ -45,7 +46,7 @@ public: // structors
     recursive_wrapper(const T& operand);
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES 
-    recursive_wrapper(recursive_wrapper&& operand);
+    recursive_wrapper(recursive_wrapper&& operand) BOOST_NOEXCEPT;
     recursive_wrapper(T&& operand);
 #endif
 
@@ -125,8 +126,8 @@ recursive_wrapper<T>::recursive_wrapper(const T& operand)
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES 
 template <typename T>
-recursive_wrapper<T>::recursive_wrapper(recursive_wrapper&& operand)
-    : p_(new T( detail::variant::move(operand.get()) ))
+recursive_wrapper<T>::recursive_wrapper(recursive_wrapper&& operand) BOOST_NOEXCEPT
+    : p_(boost::exchange(operand.p_, nullptr))
 {
 }
 

--- a/include/boost/variant/recursive_wrapper.hpp
+++ b/include/boost/variant/recursive_wrapper.hpp
@@ -95,11 +95,14 @@ public: // modifiers
 
 public: // queries
 
-    T& get() { BOOST_ASSERT(get_pointer() != NULL); return *get_pointer(); }
-    const T& get() const { BOOST_ASSERT(get_pointer() != NULL); return *get_pointer(); }
+    bool empty() const BOOST_NOEXCEPT { return get_pointer() == NULL; }
 
-    T* get_pointer() { return p_; }
-    const T* get_pointer() const { return p_; }
+    // Expects: `!empty()`.
+    T& get() BOOST_NOEXCEPT { BOOST_ASSERT(!empty()); return *get_pointer(); }
+    const T& get() const BOOST_NOEXCEPT { BOOST_ASSERT(!empty()); return *get_pointer(); }
+
+    T* get_pointer() BOOST_NOEXCEPT { return p_; }
+    const T* get_pointer() const BOOST_NOEXCEPT { return p_; }
 
 };
 

--- a/include/boost/variant/recursive_wrapper_fwd.hpp
+++ b/include/boost/variant/recursive_wrapper_fwd.hpp
@@ -66,9 +66,8 @@ template <class T, class U> struct is_constructible<recursive_wrapper<T>, const 
 template <class T, class U> struct is_constructible<recursive_wrapper<T>, recursive_wrapper<U>& >       : boost::false_type{};
 template <class T, class U> struct is_constructible<recursive_wrapper<T>, const recursive_wrapper<U>& > : boost::false_type{};
 
-// recursive_wrapper is not nothrow move constructible, because it's constructor does dynamic memory allocation.
-// This specialisation is required to workaround GCC6 issue: https://svn.boost.org/trac/boost/ticket/12680
-template <class T> struct is_nothrow_move_constructible<recursive_wrapper<T> > : boost::false_type{};
+// This specialisation is required to workaround GCC6 ICE: https://svn.boost.org/trac/boost/ticket/12680
+template <class T> struct is_nothrow_move_constructible<recursive_wrapper<T> > : boost::true_type{};
 
 ///////////////////////////////////////////////////////////////////////////////
 // metafunction is_recursive_wrapper (modeled on code by David Abrahams)

--- a/include/boost/variant/recursive_wrapper_fwd.hpp
+++ b/include/boost/variant/recursive_wrapper_fwd.hpp
@@ -67,7 +67,13 @@ template <class T, class U> struct is_constructible<recursive_wrapper<T>, recurs
 template <class T, class U> struct is_constructible<recursive_wrapper<T>, const recursive_wrapper<U>& > : boost::false_type{};
 
 // This specialisation is required to workaround GCC6 ICE: https://svn.boost.org/trac/boost/ticket/12680
-template <class T> struct is_nothrow_move_constructible<recursive_wrapper<T> > : boost::true_type{};
+template <class T> struct is_nothrow_move_constructible<recursive_wrapper<T> >
+#ifndef BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING
+    : boost::true_type{};
+#else
+// recursive_wrapper is not nothrow move constructible, because it's constructor does dynamic memory allocation.
+    : boost::false_type{};
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // metafunction is_recursive_wrapper (modeled on code by David Abrahams)

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -1109,7 +1109,7 @@ public: // internal visitor interfaces, cont.
     template <typename T>
     result_type internal_visit(const boost::recursive_wrapper<T>& operand, long)
     {
-        return operand.get_pointer() == NULL;
+        return operand.empty();
     }
 
     template <typename T>

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -1090,7 +1090,7 @@ private:
 #endif
 };
 
-class valueless_recursive_visitor
+class empty_check_visitor
 {
 public: // visitor typedefs
 
@@ -2235,7 +2235,8 @@ public: // queries
 
     bool empty() const BOOST_NOEXCEPT
     {
-        return false;
+        detail::variant::empty_check_visitor visitor;
+        return this->internal_apply_visitor(visitor);
     }
 
     const boost::typeindex::type_info& type() const
@@ -2433,12 +2434,6 @@ public: // visitation support
     {
         detail::variant::invoke_visitor<Visitor, false> invoker(visitor);
         return this->internal_apply_visitor(invoker);
-    }
-
-    bool valueless_recursive() const
-    {
-        detail::variant::valueless_recursive_visitor visitor;
-        return this->internal_apply_visitor(visitor);
     }
 
 }; // class variant

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -2235,8 +2235,12 @@ public: // queries
 
     bool empty() const BOOST_NOEXCEPT
     {
+#ifndef BOOST_VARIANT_NO_RECURSIVE_WRAPPER_POINTER_STEALING
         detail::variant::empty_check_visitor visitor;
         return this->internal_apply_visitor(visitor);
+#else
+        return false;
+#endif
     }
 
     const boost::typeindex::type_info& type() const

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -1090,6 +1090,41 @@ private:
 #endif
 };
 
+class valueless_recursive_visitor
+{
+public: // visitor typedefs
+
+    typedef bool result_type;
+
+public: // internal visitor interfaces
+
+    template <typename T>
+    result_type internal_visit(const T& operand, int)
+    {
+        return false;
+    }
+
+public: // internal visitor interfaces, cont.
+
+    template <typename T>
+    result_type internal_visit(const boost::recursive_wrapper<T>& operand, long)
+    {
+        return operand.get_pointer() == NULL;
+    }
+
+    template <typename T>
+    result_type internal_visit(const boost::detail::reference_content<T>& operand, long)
+    {
+        return internal_visit( operand.get(), 1L );
+    }
+
+    template <typename T>
+    result_type internal_visit(const boost::detail::variant::backup_holder<T>& operand, long)
+    {
+        return internal_visit( operand.get(), 1L );
+    }
+};
+
 }} // namespace detail::variant
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -2398,6 +2433,12 @@ public: // visitation support
     {
         detail::variant::invoke_visitor<Visitor, false> invoker(visitor);
         return this->internal_apply_visitor(invoker);
+    }
+
+    bool valueless_recursive() const
+    {
+        detail::variant::valueless_recursive_visitor visitor;
+        return this->internal_apply_visitor(visitor);
     }
 
 }; // class variant

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -59,6 +59,7 @@ test-suite variant
     #[ run issue53.cpp ]
     [ run overload_selection.cpp ]
     [ run recursive_wrapper_move_test.cpp ]
+    [ run recursive_wrapper_move_only_test.cpp ]
     [ run variant_over_joint_view_test.cpp ]
     [ run const_ref_apply_visitor.cpp ]
    ; 

--- a/test/recursive_wrapper_move_only_test.cpp
+++ b/test/recursive_wrapper_move_only_test.cpp
@@ -1,0 +1,55 @@
+/*=============================================================================
+  Copyright (c) 2019 Nikita Kniazev
+
+  Distributed under the Boost Software License, Version 1.0. (See accompanying
+  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+// Check that move-only types can be used with recursive_wrapper
+
+#include <boost/config.hpp>
+#ifdef BOOST_NO_CXX11_RVALUE_REFERENCES
+// variant does not support move emulation
+int main() {}
+#else
+#include "boost/core/lightweight_test.hpp"
+#include <boost/variant.hpp>
+#include <boost/move/utility_core.hpp>
+
+struct move_only_type
+{
+private:
+    BOOST_MOVABLE_BUT_NOT_COPYABLE(move_only_type)
+
+public:
+    explicit move_only_type(int value) BOOST_NOEXCEPT
+      : value_(value)
+    {}
+
+    // Move ctor
+    move_only_type(BOOST_RV_REF(move_only_type) x) BOOST_NOEXCEPT
+      : value_(x.value_)
+    {}
+
+    // Move assign
+    move_only_type& operator=(BOOST_RV_REF(move_only_type) x) BOOST_NOEXCEPT
+    {
+        value_ = x.value_;
+        return *this;
+    }
+
+    int value_;
+};
+
+int main()
+{
+    // variant does not have emplace construction yet
+    move_only_type a_(0), b_(1);
+    boost::variant<
+        boost::recursive_wrapper<move_only_type>
+    > a(boost::move(a_)), b(boost::move(b_));
+    a = boost::move(b);
+    BOOST_TEST_EQ(boost::get<move_only_type>(a).value_, 1);
+    return boost::report_errors();
+}
+#endif

--- a/test/recursive_wrapper_move_only_test.cpp
+++ b/test/recursive_wrapper_move_only_test.cpp
@@ -43,13 +43,27 @@ public:
 
 int main()
 {
-    // variant does not have emplace construction yet
+    // TODO: variant does not have inplace construction yet
     move_only_type a_(0), b_(1);
     boost::variant<
+        boost::recursive_wrapper<int>,
         boost::recursive_wrapper<move_only_type>
-    > a(boost::move(a_)), b(boost::move(b_));
+    > a(boost::move(a_)), b(boost::move(b_)), c(3);
+    BOOST_TEST(!a.valueless_recursive());
+    BOOST_TEST(!b.valueless_recursive());
     a = boost::move(b);
+    BOOST_TEST(!a.valueless_recursive());
     BOOST_TEST_EQ(boost::get<move_only_type>(a).value_, 1);
+    // check that we can reuse a moved out variant with move assignment
+    move_only_type c_(2);
+    b = boost::move(c_); // TODO: no emplace yet
+    BOOST_TEST(!b.valueless_recursive());
+    BOOST_TEST_EQ(boost::get<move_only_type>(b).value_, 2);
+    // check that recursive variant advertises its valueless after beging moved out
+    BOOST_TEST_EQ(boost::get<int>(c), 3);
+    c = boost::move(b);
+    BOOST_TEST( b.valueless_recursive());
+    BOOST_TEST_EQ(boost::get<move_only_type>(c).value_, 2);
     return boost::report_errors();
 }
 #endif

--- a/test/recursive_wrapper_move_only_test.cpp
+++ b/test/recursive_wrapper_move_only_test.cpp
@@ -49,20 +49,20 @@ int main()
         boost::recursive_wrapper<int>,
         boost::recursive_wrapper<move_only_type>
     > a(boost::move(a_)), b(boost::move(b_)), c(3);
-    BOOST_TEST(!a.valueless_recursive());
-    BOOST_TEST(!b.valueless_recursive());
+    BOOST_TEST(!a.empty());
+    BOOST_TEST(!b.empty());
     a = boost::move(b);
-    BOOST_TEST(!a.valueless_recursive());
+    BOOST_TEST(!a.empty());
     BOOST_TEST_EQ(boost::get<move_only_type>(a).value_, 1);
     // check that we can reuse a moved out variant with move assignment
     move_only_type c_(2);
     b = boost::move(c_); // TODO: no emplace yet
-    BOOST_TEST(!b.valueless_recursive());
+    BOOST_TEST(!b.empty());
     BOOST_TEST_EQ(boost::get<move_only_type>(b).value_, 2);
     // check that recursive variant advertises its valueless after beging moved out
     BOOST_TEST_EQ(boost::get<int>(c), 3);
     c = boost::move(b);
-    BOOST_TEST( b.valueless_recursive());
+    BOOST_TEST( b.empty());
     BOOST_TEST_EQ(boost::get<move_only_type>(c).value_, 2);
     return boost::report_errors();
 }


### PR DESCRIPTION
Instead of allocating a new object just steal the pointer from the other
recursive_wrapper. It is much cheaper and allows to mark the move constructor
noexcept (allows variant to move the object without backup copying it).

Fixes #58.