### PR TITLE
static_visitor: Make destructor public

### DIFF
--- a/include/boost/variant/static_visitor.hpp
+++ b/include/boost/variant/static_visitor.hpp
@@ -50,10 +50,8 @@ public: // typedefs
 protected: // for use as base class only
 #if !defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS)
     static_visitor() = default;
-    ~static_visitor() = default;
 #else
     static_visitor()  BOOST_NOEXCEPT { }
-    ~static_visitor()  BOOST_NOEXCEPT { }
 #endif
 };
 


### PR DESCRIPTION
otherwise in C++ 17 mode Clang 8 will complain about the
protected destructor:

```
main.cpp:16:33: error: temporary of type 'boost::static_visitor<>' has protected destructor
    boost::apply_visitor(output{}, v);
                                ^
/usr/local/opt/boost/include/boost/variant/static_visitor.hpp:53:5: note: declared protected here
    ~static_visitor() = default;
    ^
```

See also discussion in https://reviews.llvm.org/D53860