### PR TITLE
Partly mitigate bad Clang inlining decision

### DIFF
--- a/include/boost/variant/detail/visitation_impl.hpp
+++ b/include/boost/variant/detail/visitation_impl.hpp
@@ -190,7 +190,7 @@ template <
     , typename Visitor, typename VoidPtrCV
     , typename NoBackupFlag
     >
-inline typename Visitor::result_type
+BOOST_FORCEINLINE typename Visitor::result_type
 visitation_impl(
       const int internal_which, const int logical_which
     , Visitor& visitor, VoidPtrCV storage

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -2355,7 +2355,7 @@ public:
 #endif// !defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
 
     template <typename Visitor, typename VoidPtrCV>
-    static typename Visitor::result_type
+    BOOST_FORCEINLINE static typename Visitor::result_type
     internal_apply_visitor_impl(
           int internal_which
         , int logical_which
@@ -2380,7 +2380,7 @@ public:
     }
 
     template <typename Visitor>
-    typename Visitor::result_type
+    BOOST_FORCEINLINE typename Visitor::result_type
     internal_apply_visitor(Visitor& visitor)
     {
         return internal_apply_visitor_impl(
@@ -2389,7 +2389,7 @@ public:
     }
 
     template <typename Visitor>
-    typename Visitor::result_type
+    BOOST_FORCEINLINE typename Visitor::result_type
     internal_apply_visitor(Visitor& visitor) const
     {
         return internal_apply_visitor_impl(


### PR DESCRIPTION
Because a visitor is wrapped several times during visitation it cases extra temporaries usage and useless store and loads that can only be optimized if the `visitation_impl` is inlined into the function that creates the wrapper. Clang inliner decides not to inline functions even with small-sized switches, resulting in a poor visitation code. Forceinline mark on those internal functions perceptibly improves the situation, though does not mitigate it completely.

LLVM ticket https://bugs.llvm.org/show_bug.cgi?id=41491

Before:
```asm
foo:
	sub	rsp, 88
	lea	rax, [rsp + 64]
	mov	qword ptr [rsp + 72], rax
	lea	rax, [rsp + 72]
	mov	qword ptr [rsp + 80], rax
	mov	eax, dword ptr [rcx]
	lea	r9, [rcx + 4]
	mov	edx, eax
	sar	edx, 31
	xor	edx, eax
	xorps	xmm0, xmm0
	movups	xmmword ptr [rsp + 48], xmm0
	lea	r8, [rsp + 80]
	mov	ecx, eax
	call	tail
	nop
	add	rsp, 88
	ret

tail:
	add	edx, -1
	cmp	edx, 8
	ja	.LBB1_2
	lea	rax, [rip + .LJTI1_0]
	movsxd	rcx, dword ptr [rax + 4*rdx]
	add	rcx, rax
	jmp	rcx
```

After:
```asm
foo:
	sub	rsp, 56
	lea	rax, [rsp + 40]
	mov	qword ptr [rsp + 48], rax
	lea	rdx, [rsp + 48]
	call	tail
	nop
	add	rsp, 56
	ret

tail:
	mov	ecx, dword ptr [rcx]
	mov	eax, ecx
	sar	eax, 31
	xor	eax, ecx
	add	eax, -1
	cmp	eax, 8
	ja	.LBB1_2
	lea	rcx, [rip + .LJTI1_0]
	movsxd	rax, dword ptr [rcx + 4*rax]
	add	rax, rcx
	jmp	rax
```