### PR TITLE
Remove unused includes

### DIFF
--- a/include/boost/variant/detail/apply_visitor_binary.hpp
+++ b/include/boost/variant/detail/apply_visitor_binary.hpp
@@ -25,8 +25,7 @@
 #   include <boost/core/enable_if.hpp>
 #   include <boost/type_traits/is_lvalue_reference.hpp>
 #   include <boost/type_traits/is_same.hpp>
-#   include <boost/move/move.hpp>
-#   include <boost/move/utility.hpp>
+#   include <boost/move/utility_core.hpp> // for boost::move, boost::forward
 #endif
 
 namespace boost {

--- a/include/boost/variant/detail/move.hpp
+++ b/include/boost/variant/detail/move.hpp
@@ -20,12 +20,9 @@
 #ifndef BOOST_VARIANT_DETAIL_MOVE_HPP
 #define BOOST_VARIANT_DETAIL_MOVE_HPP
 
-#include <iterator> // for iterator_traits
-#include <new> // for placement new
-
 #include <boost/config.hpp>
 #include <boost/detail/workaround.hpp>
-#include <boost/move/move.hpp>
+#include <boost/move/utility_core.hpp> // for boost::move
 #include <boost/move/adl_move_swap.hpp>
 
 namespace boost { namespace detail { namespace variant {

--- a/test/recursive_wrapper_move_test.cpp
+++ b/test/recursive_wrapper_move_test.cpp
@@ -15,7 +15,6 @@
 // is_noexcept_move_constructible
 
 #include <string>
-#include <iterator>
 
 #include <boost/variant.hpp>
 #include <boost/array.hpp>


### PR DESCRIPTION
`-fsyntax-only` times for `#include <boost/variant.hpp>`
```
mingw    0.72 -> 0.56 (22%)
clang-cl 0.85 -> 0.70 (18%)
```
