### PR TITLE
Fix GCC zero-as-null-pointer-constat warnings

### DIFF
--- a/include/boost/variant/detail/apply_visitor_binary.hpp
+++ b/include/boost/variant/detail/apply_visitor_binary.hpp
@@ -261,13 +261,13 @@ public: // structors
 public: // visitor interfaces
 
     template <typename Value2>
-    decltype(auto) operator()(Value2&& value2, typename enable_if_c<MoveSemantics && is_same<Value2, Value2>::value>::type* = 0)
+    decltype(auto) operator()(Value2&& value2, typename enable_if_c<MoveSemantics && is_same<Value2, Value2>::value, bool>::type = true)
     {
         return visitor_(::boost::move(value1_), ::boost::forward<Value2>(value2));
     }
 
     template <typename Value2>
-    decltype(auto) operator()(Value2&& value2, typename disable_if_c<MoveSemantics && is_same<Value2, Value2>::value>::type* = 0)
+    decltype(auto) operator()(Value2&& value2, typename disable_if_c<MoveSemantics && is_same<Value2, Value2>::value, bool>::type = true)
     {
         return visitor_(value1_, ::boost::forward<Value2>(value2));
     }
@@ -293,7 +293,7 @@ public: // structors
 public: // visitor interfaces
 
     template <typename Value1>
-    decltype(auto) operator()(Value1&& value1, typename enable_if_c<MoveSemantics && is_same<Value1, Value1>::value>::type* = 0)
+    decltype(auto) operator()(Value1&& value1, typename enable_if_c<MoveSemantics && is_same<Value1, Value1>::value, bool>::type = true)
     {
         apply_visitor_binary_invoke_cpp14<
               Visitor
@@ -305,7 +305,7 @@ public: // visitor interfaces
     }
 
     template <typename Value1>
-    decltype(auto) operator()(Value1&& value1, typename disable_if_c<MoveSemantics && is_same<Value1, Value1>::value>::type* = 0)
+    decltype(auto) operator()(Value1&& value1, typename disable_if_c<MoveSemantics && is_same<Value1, Value1>::value, bool>::type = true)
     {
         apply_visitor_binary_invoke_cpp14<
               Visitor
@@ -325,8 +325,9 @@ private:
 template <typename Visitor, typename Visitable1, typename Visitable2>
 inline decltype(auto) apply_visitor(Visitor& visitor, Visitable1&& visitable1, Visitable2&& visitable2,
     typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
+        boost::detail::variant::has_result_type<Visitor>,
+        bool
+    >::type = true)
 {
     ::boost::detail::variant::apply_visitor_binary_unwrap_cpp14<
           Visitor, Visitable2, ! ::boost::is_lvalue_reference<Visitable2>::value
@@ -338,8 +339,9 @@ inline decltype(auto) apply_visitor(Visitor& visitor, Visitable1&& visitable1, V
 template <typename Visitor, typename Visitable1, typename Visitable2>
 inline decltype(auto) apply_visitor(const Visitor& visitor, Visitable1&& visitable1, Visitable2&& visitable2,
     typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
+        boost::detail::variant::has_result_type<Visitor>,
+        bool
+    >::type = true)
 {
     ::boost::detail::variant::apply_visitor_binary_unwrap_cpp14<
           const Visitor, Visitable2, ! ::boost::is_lvalue_reference<Visitable2>::value

--- a/include/boost/variant/detail/apply_visitor_unary.hpp
+++ b/include/boost/variant/detail/apply_visitor_unary.hpp
@@ -130,8 +130,9 @@ struct result_wrapper1
 template <typename Visitor, typename Visitable>
 inline decltype(auto) apply_visitor(Visitor&& visitor, Visitable&& visitable,
     typename boost::disable_if<
-        boost::detail::variant::has_result_type<Visitor>
-    >::type* = 0)
+        boost::detail::variant::has_result_type<Visitor>,
+        bool
+    >::type = true)
 {
     boost::detail::variant::result_wrapper1<Visitor, Visitable> cpp14_vis(::boost::forward<Visitor>(visitor));
     return ::boost::forward<Visitable>(visitable).apply_visitor(cpp14_vis);

--- a/include/boost/variant/detail/multivisitors_cpp14_based.hpp
+++ b/include/boost/variant/detail/multivisitors_cpp14_based.hpp
@@ -19,7 +19,7 @@
 
 #include <boost/variant/detail/multivisitors_cpp14_based.hpp>
 
-namespace boost { 
+namespace boost {
 
 namespace detail { namespace variant {
 
@@ -106,8 +106,9 @@ namespace detail { namespace variant {
     template <class Visitor, class T1, class T2, class T3, class... TN>
     inline decltype(auto) apply_visitor(const Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn,
         typename boost::disable_if<
-            boost::detail::variant::has_result_type<Visitor>
-        >::type* = 0)
+            boost::detail::variant::has_result_type<Visitor>,
+            bool
+        >::type = true)
     {
         return boost::apply_visitor(
             ::boost::detail::variant::make_one_by_one_visitor_and_value_referer_cpp14(
@@ -122,13 +123,14 @@ namespace detail { namespace variant {
             ::boost::forward<T1>(v1)
         );
     }
-    
+
 
     template <class Visitor, class T1, class T2, class T3, class... TN>
     inline decltype(auto) apply_visitor(Visitor& visitor, T1&& v1, T2&& v2, T3&& v3, TN&&... vn,
         typename boost::disable_if<
-            boost::detail::variant::has_result_type<Visitor>
-        >::type* = 0)
+            boost::detail::variant::has_result_type<Visitor>,
+            bool
+        >::type = true)
     {
         return ::boost::apply_visitor(
             ::boost::detail::variant::make_one_by_one_visitor_and_value_referer_cpp14(

--- a/include/boost/variant/detail/visitation_impl.hpp
+++ b/include/boost/variant/detail/visitation_impl.hpp
@@ -34,9 +34,9 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/type_traits/is_nothrow_move_constructible.hpp>
 
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400) 
-# pragma warning (push) 
-# pragma warning (disable : 4702) //unreachable code 
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
+# pragma warning (push)
+# pragma warning (disable : 4702) //unreachable code
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,6 +56,13 @@
         BOOST_VARIANT_LIMIT_TYPES
 #endif
 
+#endif
+
+// Define a compiler generic null pointer value
+#if defined(BOOST_NO_NULLPTR)
+#define BOOST_VARIANT_NULL 0
+#else
+#define BOOST_VARIANT_NULL nullptr
 #endif
 
 namespace boost {
@@ -177,7 +184,7 @@ inline typename Visitor::result_type
 visitation_impl(
       int, int, Visitor&, VPCV
     , mpl::true_ // is_apply_visitor_unrolled
-    , NBF, W* = 0, S* = 0
+    , NBF, W* = BOOST_VARIANT_NULL, S* = BOOST_VARIANT_NULL
     )
 {
     // should never be here at runtime!
@@ -196,7 +203,7 @@ visitation_impl(
     , Visitor& visitor, VoidPtrCV storage
     , mpl::false_ // is_apply_visitor_unrolled
     , NoBackupFlag no_backup_flag
-    , Which* = 0, step0* = 0
+    , Which* = BOOST_VARIANT_NULL, step0* = BOOST_VARIANT_NULL
     )
 {
     // Typedef apply_visitor_unrolled steps and associated types...
@@ -263,8 +270,8 @@ visitation_impl(
 }} // namespace detail::variant
 } // namespace boost
 
-#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)  
-# pragma warning(pop)  
-#endif 
+#if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
+# pragma warning(pop)
+#endif
 
 #endif // BOOST_VARIANT_DETAIL_VISITATION_IMPL_HPP

--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -102,8 +102,13 @@ public: // visitor interfaces
 #   if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0551))
 #       define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)
 #   else
-#       define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
-        , t* = 0
+#       if defined(BOOST_NO_NULLPTR)
+#           define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
+            , t* = 0
+#       else
+#           define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
+            , t* = nullptr
+#       endif
 #   endif
 #endif
 

--- a/include/boost/variant/polymorphic_get.hpp
+++ b/include/boost/variant/polymorphic_get.hpp
@@ -135,8 +135,13 @@ public: // visitor interfaces
 #   if !BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x0551))
 #       define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)
 #   else
-#       define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
-        , t* = 0
+#       if defined(BOOST_NO_NULLPTR)
+#           define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
+            , t* = 0
+#       else
+#           define BOOST_VARIANT_AUX_GET_EXPLICIT_TEMPLATE_TYPE(t)  \
+            , t* = nullptr
+#       endif
 #   endif
 #endif
 

--- a/include/boost/variant/variant.hpp
+++ b/include/boost/variant/variant.hpp
@@ -130,7 +130,7 @@ private: // helpers, for metafunction result (below)
 
     typedef typename mpl::transform1<Sequence, F>::type transformed_;
     typedef typename mpl::max_element<transformed_
-          
+
         >::type max_it;
 
 public: // metafunction result
@@ -1372,15 +1372,15 @@ public: // structors
         destroy_content();
     }
 
-    variant() 
+    variant()
 #if !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5130))
               BOOST_NOEXCEPT_IF(boost::has_nothrow_constructor<internal_T0>::value)
 #endif
     {
 #ifdef _MSC_VER
 #pragma warning( push )
-// behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized 
-#pragma warning( disable : 4345 ) 
+// behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized
+#pragma warning( disable : 4345 )
 #endif
         // NOTE TO USER :
         // Compile error from here indicates that the first bound
@@ -1416,7 +1416,7 @@ private: // helpers, for structors, cont. (below)
         int internal_visit(T& operand, int) const
         {
             // NOTE TO USER :
-            // Compile error here indicates one of the source variant's types 
+            // Compile error here indicates one of the source variant's types
             // cannot be unambiguously converted to the destination variant's
             // types (or that no conversion exists).
             //
@@ -1492,7 +1492,7 @@ private: // helpers, for structors, cont. (below)
         int internal_visit(T& operand, int) const
         {
             // NOTE TO USER :
-            // Compile error here indicates one of the source variant's types 
+            // Compile error here indicates one of the source variant's types
             // cannot be unambiguously converted to the destination variant's
             // types (or that no conversion exists).
             //
@@ -1539,7 +1539,7 @@ private: // helpers, for structors, cont. (below)
     friend class convert_move_into;
 #endif
 
-private: // helpers, for structors, below 
+private: // helpers, for structors, below
 
     template <typename T>
     void convert_construct(
@@ -1549,7 +1549,7 @@ private: // helpers, for structors, below
         )
     {
         // NOTE TO USER :
-        // Compile error here indicates that the given type is not 
+        // Compile error here indicates that the given type is not
         // unambiguously convertible to one of the variant's types
         // (or that no conversion exists).
         //
@@ -1570,7 +1570,7 @@ private: // helpers, for structors, below
         )
     {
         // NOTE TO USER :
-        // Compile error here indicates that the given type is not 
+        // Compile error here indicates that the given type is not
         // unambiguously convertible to one of the variant's types
         // (or that no conversion exists).
         //
@@ -1688,7 +1688,7 @@ private: // helpers, for structors, below
         , long
         )
     {
-        convert_construct_variant(operand);    
+        convert_construct_variant(operand);
     }
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
@@ -1701,7 +1701,7 @@ private: // helpers, for structors, below
         , long
         )
     {
-        convert_construct_variant( detail::variant::move(operand) );    
+        convert_construct_variant( detail::variant::move(operand) );
     }
 #endif
 
@@ -1713,8 +1713,9 @@ public: // structors, cont.
             mpl::and_<
                 mpl::not_< boost::is_same<T, variant> >,
                 boost::detail::variant::is_variant_constructible_from<const T&, internal_types>
-            >, 
-            boost::is_same<T, boost::recursive_variant_> > >::type* = 0)
+            >,
+            boost::is_same<T, boost::recursive_variant_> >,
+            bool >::type = true)
     {
         convert_construct(operand, 1L);
     }
@@ -1728,7 +1729,8 @@ public: // structors, cont.
                 mpl::not_< boost::is_same<T, variant> >,
                 boost::detail::variant::is_variant_constructible_from<T&, internal_types>
             >,
-            boost::is_same<T, boost::recursive_variant_> > >::type* = 0
+            boost::is_same<T, boost::recursive_variant_> >,
+            bool >::type = true
         )
     {
         convert_construct(operand, 1L);
@@ -1744,7 +1746,8 @@ public: // structors, cont.
                 mpl::not_< boost::is_same<T, variant> >,
                 boost::detail::variant::is_variant_constructible_from<T&&, internal_types>
             >,
-            boost::is_same<T, boost::recursive_variant_> > >::type* = 0)
+            boost::is_same<T, boost::recursive_variant_> >,
+            bool >::type = true)
     {
         convert_construct( detail::variant::move(operand), 1L);
     }
@@ -1927,9 +1930,9 @@ private: // helpers, for modifiers (below)
         assigner& operator= (assigner const&);
 #endif
     };
-    
+
     friend class assigner;
-   
+
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
     // class move_assigner
     //
@@ -1948,7 +1951,7 @@ private: // helpers, for modifiers (below)
         }
 
     private: // helpers, for internal visitor interface (below)
-        
+
         template <typename RhsT, typename B2>
         void assign_impl(
               RhsT& rhs_content
@@ -2008,7 +2011,7 @@ private: // helpers, for modifiers (below)
             // In the event of success, indicate new content type:
             assigner::lhs_.indicate_which(assigner::rhs_which_); // nothrow
         }
-        
+
         template <typename RhsT>
         void assign_impl(
               RhsT& rhs_content
@@ -2063,7 +2066,7 @@ private: // helpers, for modifiers (below)
         {
             // Otherwise, perform general (copy-based) variant assignment:
             assigner visitor(*this, rhs.which());
-            rhs.internal_apply_visitor(visitor); 
+            rhs.internal_apply_visitor(visitor);
         }
     }
 
@@ -2081,7 +2084,7 @@ private: // helpers, for modifiers (below)
         {
             // Otherwise, perform general (move-based) variant assignment:
             move_assigner visitor(*this, rhs.which());
-            rhs.internal_apply_visitor(visitor); 
+            rhs.internal_apply_visitor(visitor);
         }
     }
 #endif // BOOST_NO_CXX11_RVALUE_REFERENCES
@@ -2137,7 +2140,7 @@ public: // modifiers
             boost::detail::variant::is_variant_constructible_from<T&&, internal_types>
         >,
         variant&
-    >::type operator=(T&& rhs) 
+    >::type operator=(T&& rhs)
     {
         move_assign( detail::variant::move(rhs) );
         return *this;
@@ -2165,7 +2168,7 @@ public: // modifiers
     }
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-    variant& operator=(variant&& rhs) 
+    variant& operator=(variant&& rhs)
 #if !defined(__GNUC__) || (__GNUC__ != 4) || (__GNUC_MINOR__ > 6) || defined(__clang__)
         BOOST_NOEXCEPT_IF(variant_move_noexcept_constructible::type::value && variant_move_noexcept_assignable::type::value)
 #endif

--- a/test/variant_visit_test.cpp
+++ b/test/variant_visit_test.cpp
@@ -79,7 +79,7 @@ struct rvalue_ref_decltype_visitor
 #endif
 
 template <typename Checker, typename Variant>
-inline void unary_test(Variant& var, Checker* = 0)
+inline void unary_test(Variant& var, Checker* = BOOST_VARIANT_NULL)
 {
     Checker checker;
     const Checker& const_checker = checker;
@@ -97,7 +97,7 @@ inline void unary_test(Variant& var, Checker* = 0)
 }
 
 template <typename Checker, typename Variant1, typename Variant2>
-inline void binary_test(Variant1& var1, Variant2& var2, Checker* = 0)
+inline void binary_test(Variant1& var1, Variant2& var2, Checker* = BOOST_VARIANT_NULL)
 {
     Checker checker;
     const Checker& const_checker = checker;


### PR DESCRIPTION
Fixes GCC's zero-as-null-pointer-constat warnings.
Resolves issue #76 