### PR TITLE
Add missing include

### DIFF
--- a/include/boost/variant/bad_visit.hpp
+++ b/include/boost/variant/bad_visit.hpp
@@ -13,6 +13,8 @@
 #ifndef BOOST_VARIANT_BAD_VISIT_HPP
 #define BOOST_VARIANT_BAD_VISIT_HPP
 
+#include <boost/config.hpp>
+
 #include <exception>
 
 namespace boost {


### PR DESCRIPTION
Allow header file to be built standalone, in a clang C++ modules context.