### PR TITLE
refactor: use core/checked_delete over checked_delete

### DIFF
--- a/include/boost/variant/recursive_wrapper.hpp
+++ b/include/boost/variant/recursive_wrapper.hpp
@@ -15,7 +15,7 @@
 
 #include <boost/variant/recursive_wrapper_fwd.hpp>
 #include <boost/variant/detail/move.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 
 namespace boost {
 


### PR DESCRIPTION
The later has been deprecated:
```cpp

// The header file at this path is deprecated;
// use boost/core/checked_delete.hpp instead.

```