### PR TITLE
Detect compatible types via overload resolution

### DIFF
--- a/test/recursive_variant_test.cpp
+++ b/test/recursive_variant_test.cpp
@@ -363,7 +363,7 @@ void test_recursive_variant_from_variant()
     typedef boost::variant<Nil, double> Atom;
     typedef boost::variant<Nil, boost::recursive_wrapper<Atom> > Variant;
 
-    BOOST_STATIC_ASSERT(!boost::is_constructible<Variant, Atom>::value);
+    BOOST_STATIC_ASSERT(boost::is_constructible<Variant, Atom>::value);
     BOOST_STATIC_ASSERT(boost::is_constructible<boost::variant<Nil, Atom>, Atom>::value);
 }
 


### PR DESCRIPTION
Use an overload set to detect if a type can be used in a converting constructor or assignment, in a similar way as std::variant.

Fix the behavior of is_constructible, is_assignable and is_convertible traits with boost variant reported in #102.
Also fix the "regression" mentioned in #100.