### PR TITLE
refactor: use core/addressof over utility/addressof

### DIFF
--- a/include/boost/variant/get.hpp
+++ b/include/boost/variant/get.hpp
@@ -16,10 +16,10 @@
 #include <exception>
 
 #include <boost/config.hpp>
+#include <boost/core/addressof.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/utility/addressof.hpp>
 #include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/detail/element_index.hpp>
 #include <boost/variant/detail/move.hpp>

--- a/include/boost/variant/polymorphic_get.hpp
+++ b/include/boost/variant/polymorphic_get.hpp
@@ -15,10 +15,10 @@
 #include <exception>
 
 #include <boost/config.hpp>
+#include <boost/core/addressof.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/utility/addressof.hpp>
 #include <boost/variant/variant_fwd.hpp>
 #include <boost/variant/get.hpp>
 


### PR DESCRIPTION
The later is deprecated.