### PR TITLE
Remove deprecated `boost/swap.hpp` include

### DIFF
--- a/test/rvalue_test.cpp
+++ b/test/rvalue_test.cpp
@@ -17,7 +17,6 @@
 #include "boost/mpl/bool.hpp"
 
 #include <boost/blank.hpp>
-#include <boost/swap.hpp>
 
 namespace swap_ambiguouty_test_ns {
     struct A {};


### PR DESCRIPTION
This header is deprecated and will be removed. There is `boost/core/invoke_swap.hpp` as a replacement, but it isn't needed in this case.