### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/variant

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,34 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/variant
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/config//boost_config
+        <source>/boost/container_hash//boost_container_hash
+        <source>/boost/core//boost_core
+        <source>/boost/detail//boost_detail
+        <source>/boost/integer//boost_integer
+        <source>/boost/move//boost_move
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_index//boost_type_index
+        <source>/boost/type_traits//boost_type_traits
+        <source>/boost/utility//boost_utility
+        <include>include
+    ;
+
+explicit
+    [ alias boost_variant ]
+    [ alias all : boost_variant test ]
+    ;
+
+call-if : boost-library variant
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,28 +5,31 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/container_hash//boost_container_hash
+    /boost/core//boost_core
+    /boost/detail//boost_detail
+    /boost/integer//boost_integer
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_index//boost_type_index
+    /boost/type_traits//boost_type_traits
+    /boost/utility//boost_utility ;
+
 project /boost/variant
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/container_hash//boost_container_hash
-        <library>/boost/core//boost_core
-        <library>/boost/detail//boost_detail
-        <library>/boost/integer//boost_integer
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_index//boost_type_index
-        <library>/boost/type_traits//boost_type_traits
-        <library>/boost/utility//boost_utility
         <include>include
     ;
 
 explicit
-    [ alias boost_variant ]
+    [ alias boost_variant : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_variant test ]
     ;
 
 call-if : boost-library variant
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,21 +7,21 @@ import project ;
 
 project /boost/variant
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/config//boost_config
-        <source>/boost/container_hash//boost_container_hash
-        <source>/boost/core//boost_core
-        <source>/boost/detail//boost_detail
-        <source>/boost/integer//boost_integer
-        <source>/boost/move//boost_move
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_index//boost_type_index
-        <source>/boost/type_traits//boost_type_traits
-        <source>/boost/utility//boost_utility
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/config//boost_config
+        <library>/boost/container_hash//boost_container_hash
+        <library>/boost/core//boost_core
+        <library>/boost/detail//boost_detail
+        <library>/boost/integer//boost_integer
+        <library>/boost/move//boost_move
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_index//boost_type_index
+        <library>/boost/type_traits//boost_type_traits
+        <library>/boost/utility//boost_utility
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/variant
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -10,13 +10,11 @@ import project ;
 project /boost/variant
     : common-requirements
         <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
         <library>/boost/config//boost_config
         <library>/boost/container_hash//boost_container_hash
         <library>/boost/core//boost_core
         <library>/boost/detail//boost_detail
         <library>/boost/integer//boost_integer
-        <library>/boost/move//boost_move
         <library>/boost/mpl//boost_mpl
         <library>/boost/preprocessor//boost_preprocessor
         <library>/boost/static_assert//boost_static_assert

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -32,7 +32,7 @@ test-suite variant
     [ run test6.cpp : : : : variant_test6 ]
     [ run test7.cpp : : : : variant_test7 ]
     [ run test8.cpp : : : : variant_test8 ]
-    [ run test9.cpp : : : <source>/boost/fusion//boost_fusion : variant_test9 ]
+    [ run test9.cpp : : : <library>/boost/fusion//boost_fusion : variant_test9 ]
     [ run recursive_variant_test.cpp ]
     [ run variant_reference_test.cpp ]
     [ run variant_comparison_test.cpp ]
@@ -41,7 +41,7 @@ test-suite variant
     [ run variant_get_test.cpp ]
     [ compile-fail variant_rvalue_get_with_ampersand_test.cpp ]
     [ compile-fail no_rvalue_to_nonconst_visitation.cpp ]
-    [ compile fusion_interop.cpp : <source>/boost/fusion//boost_fusion ]
+    [ compile fusion_interop.cpp : <library>/boost/fusion//boost_fusion ]
     [ run variant_polymorphic_get_test.cpp ]
     [ run variant_multivisit_test.cpp ]
     [ run hash_variant_test.cpp ]
@@ -60,13 +60,13 @@ test-suite variant
     [ run recursive_variant_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : variant_no_rtti_test ]
     [ run hash_recursive_variant_test.cpp ]
     [ run variant_swap_test.cpp ]
-    [ run auto_visitors.cpp : : : <source>/boost/lexical_cast//boost_lexical_cast ]
+    [ run auto_visitors.cpp : : : <library>/boost/lexical_cast//boost_lexical_cast ]
     [ run issue42.cpp ]
-    [ run issue53.cpp : : : <source>/boost/thread//boost_thread ]
+    [ run issue53.cpp : : : <library>/boost/thread//boost_thread ]
     [ run overload_selection.cpp : : : "<cxxstd>$(since_cpp20)"\:<build>no ]
-    [ run recursive_wrapper_move_test.cpp : : : <source>/boost/array//boost_array ]
+    [ run recursive_wrapper_move_test.cpp : : : <library>/boost/array//boost_array ]
     [ run variant_over_joint_view_test.cpp ]
-    [ run const_ref_apply_visitor.cpp : : : <source>/boost/lexical_cast//boost_lexical_cast ]
-   ; 
+    [ run const_ref_apply_visitor.cpp : : : <library>/boost/lexical_cast//boost_lexical_cast ]
+   ;
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,8 +8,10 @@
 # http://www.boost.org/LICENSE_1_0.txt)
 #
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 import testing ;
-import ../../config/checks/config : requires ;
 
 local below_cpp14 = 98 03 0x 11 ;
 local since_cpp20 = 2a 20 latest ;
@@ -30,7 +32,7 @@ test-suite variant
     [ run test6.cpp : : : : variant_test6 ]
     [ run test7.cpp : : : : variant_test7 ]
     [ run test8.cpp : : : : variant_test8 ]
-    [ run test9.cpp : : : : variant_test9 ]
+    [ run test9.cpp : : : <source>/boost/fusion//boost_fusion : variant_test9 ]
     [ run recursive_variant_test.cpp ]
     [ run variant_reference_test.cpp ]
     [ run variant_comparison_test.cpp ]
@@ -39,7 +41,7 @@ test-suite variant
     [ run variant_get_test.cpp ]
     [ compile-fail variant_rvalue_get_with_ampersand_test.cpp ]
     [ compile-fail no_rvalue_to_nonconst_visitation.cpp ]
-    [ compile fusion_interop.cpp ]
+    [ compile fusion_interop.cpp : <source>/boost/fusion//boost_fusion ]
     [ run variant_polymorphic_get_test.cpp ]
     [ run variant_multivisit_test.cpp ]
     [ run hash_variant_test.cpp ]
@@ -58,13 +60,13 @@ test-suite variant
     [ run recursive_variant_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : variant_no_rtti_test ]
     [ run hash_recursive_variant_test.cpp ]
     [ run variant_swap_test.cpp ]
-    [ run auto_visitors.cpp ]
+    [ run auto_visitors.cpp : : : <source>/boost/lexical_cast//boost_lexical_cast ]
     [ run issue42.cpp ]
-    [ run issue53.cpp ]
+    [ run issue53.cpp : : : <source>/boost/thread//boost_thread ]
     [ run overload_selection.cpp : : : "<cxxstd>$(since_cpp20)"\:<build>no ]
-    [ run recursive_wrapper_move_test.cpp ]
+    [ run recursive_wrapper_move_test.cpp : : : <source>/boost/array//boost_array ]
     [ run variant_over_joint_view_test.cpp ]
-    [ run const_ref_apply_visitor.cpp ]
+    [ run const_ref_apply_visitor.cpp : : : <source>/boost/lexical_cast//boost_lexical_cast ]
    ; 
 
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -18,6 +18,7 @@ local since_cpp20 = 2a 20 latest ;
 
 project
     : requirements
+        <library>/boost/variant//boost_variant
         [ requires cxx11_rvalue_references ]
         <toolset>msvc:<asynch-exceptions>on
     ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.