### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ target_link_libraries( boost_variant
         Boost::integer
         Boost::mpl
         Boost::preprocessor
-        Boost::static_assert
         Boost::throw_exception
         Boost::type_index
         Boost::type_traits

--- a/build.jam
+++ b/build.jam
@@ -14,7 +14,6 @@ constant boost_dependencies :
     /boost/integer//boost_integer
     /boost/mpl//boost_mpl
     /boost/preprocessor//boost_preprocessor
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_index//boost_type_index
     /boost/type_traits//boost_type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.